### PR TITLE
feat: MCP + UTCP agent integration

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -10,3 +10,6 @@ jobs:
   build_tests:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
+    with:
+      install_extras: 'mcp'
+      test_path: 'test'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,100 @@ then you can do get requests
 - `http://0.0.0.0:9686/translate/pt/en/o meu nome é Casimiro`  (specify source lang)
 - `http://0.0.0.0:9686/detect/o meu nome é Casimiro`
 
+## AI Agent Integration
+
+### UTCP — Universal Tool Calling Protocol
+
+Every running instance of the server exposes a machine-readable
+[UTCP](https://github.com/universal-tool-calling-protocol/python-utcp) manual at:
+
+```
+GET /utcp
+```
+
+The manual describes all translation and detection endpoints as **HTTP tools**
+so UTCP-compatible AI agents can discover and invoke them directly — no extra
+proxy layer required.  The URLs in the manual use the same host/port the
+request arrived on, so the document is always self-consistent under any
+reverse-proxy deployment.
+
+```bash
+curl http://localhost:9686/utcp | python3 -m json.tool
+```
+
+**Exposed tools**
+
+| UTCP tool name | Description |
+|---|---|
+| `ovos_translate.translate` | Translate text, source language auto-detected |
+| `ovos_translate.translate_with_source` | Translate text with explicit source language |
+| `ovos_translate.detect_language` | Return the BCP-47 language tag of a string |
+| `ovos_translate.classify_language` | Return per-language confidence scores |
+| `ovos_translate.supported_languages` | List all supported language codes |
+
+No extra dependency is required for UTCP; the `/utcp` endpoint is always
+registered when the server starts.
+
+### MCP — Model Context Protocol
+
+An optional [MCP](https://modelcontextprotocol.io) server is embedded in
+the main application when the `mcp` extra is installed:
+
+```bash
+pip install "ovos-translate-server[mcp]"
+```
+
+Once installed, the MCP endpoint is automatically mounted at `/mcp` using
+the Streamable HTTP transport.  Agents that speak MCP (Claude Desktop,
+Continue, etc.) can add it as a server at:
+
+```
+http://localhost:9686/mcp
+```
+
+**MCP tools**
+
+| Tool | Arguments | Returns |
+|---|---|---|
+| `translate` | `text`, `target_lang`, `source_lang` (optional) | translated string |
+| `detect_language` | `text` | BCP-47 language tag |
+
+#### Standalone MCP process
+
+If you prefer to run the MCP server as a separate process (e.g. to bind it
+to `localhost` only while the HTTP API is public):
+
+```bash
+python -m ovos_translate_server.mcp_server \
+    --tx-engine ovos-translate-plugin-nllb \
+    --detect-engine ovos-lang-detector-classics-plugin \
+    --host 127.0.0.1 \
+    --port 9687
+```
+
+#### Embedding in a custom FastAPI app
+
+```python
+from ovos_translate_server import start_translate_server
+from ovos_translate_server.mcp_server import get_mcp_app
+
+app, engine = start_translate_server("ovos-translate-plugin-nllb")
+# MCP is already mounted at /mcp; or mount it manually at a custom path:
+# app.mount("/my-mcp", get_mcp_app(engine))
+```
+
+#### Claude Desktop configuration
+
+```json
+{
+  "mcpServers": {
+    "ovos-translate": {
+      "url": "http://localhost:9686/mcp"
+    }
+  }
+}
+```
+
 ## Docker
 
 you can create easily crete a docker file to serve any plugin

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -159,8 +159,8 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
     # MCP server — optional, requires `pip install ovos-translate-server[mcp]`
     # ------------------------------------------------------------------
     try:
-        from ovos_translate_server.mcp_server import get_mcp_app
-        app.mount("/mcp", get_mcp_app(engine))
+        from ovos_translate_server.mcp_server import mount_mcp
+        mount_mcp(app, engine)
         LOG.info("MCP server mounted at /mcp")
     except ImportError:
         LOG.debug(

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -137,6 +137,37 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
 
 
 
+    # ------------------------------------------------------------------
+    # UTCP manual endpoint — no extra dependency required
+    # ------------------------------------------------------------------
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+    from ovos_translate_server.utcp_manual import build_utcp_manual
+
+    @app.get("/utcp", include_in_schema=True, summary="UTCP manual")
+    def utcp_manual(request: Request) -> JSONResponse:
+        """Return the UTCP manual describing all HTTP tool endpoints.
+
+        The manual follows the Universal Tool Calling Protocol schema so
+        that UTCP-compatible AI agents can discover and invoke the
+        translation endpoints directly without an extra proxy layer.
+        """
+        base_url = str(request.base_url).rstrip("/")
+        return JSONResponse(build_utcp_manual(base_url))
+
+    # ------------------------------------------------------------------
+    # MCP server — optional, requires `pip install ovos-translate-server[mcp]`
+    # ------------------------------------------------------------------
+    try:
+        from ovos_translate_server.mcp_server import get_mcp_app
+        app.mount("/mcp", get_mcp_app(engine))
+        LOG.info("MCP server mounted at /mcp")
+    except ImportError:
+        LOG.debug(
+            "MCP support not available. "
+            "Install with: pip install 'ovos-translate-server[mcp]'"
+        )
+
     return app
 
 

--- a/ovos_translate_server/mcp_server.py
+++ b/ovos_translate_server/mcp_server.py
@@ -33,7 +33,12 @@ The FastMCP instance can also be embedded in an existing FastAPI app via
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+    from starlette.applications import Starlette
+    from ovos_translate_server import TranslateEngineWrapper
 
 __all__ = [
     "build_mcp",
@@ -42,7 +47,7 @@ __all__ = [
 ]
 
 
-def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":  # noqa: F821
+def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":
     """Build and return a :class:`~mcp.server.fastmcp.FastMCP` instance.
 
     The instance exposes *translate* and *detect_language* tools backed by the
@@ -115,7 +120,7 @@ def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":  # noqa: F821
     return mcp
 
 
-def get_mcp_app(engine: "TranslateEngineWrapper") -> "Starlette":  # noqa: F821
+def get_mcp_app(engine: "TranslateEngineWrapper") -> "Starlette":
     """Return an ASGI app that serves the MCP server over Streamable HTTP.
 
     This can be mounted into an existing FastAPI / Starlette application::

--- a/ovos_translate_server/mcp_server.py
+++ b/ovos_translate_server/mcp_server.py
@@ -1,0 +1,171 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Optional MCP server for the OVOS Translate service.
+
+Exposes two tools via the Model Context Protocol (MCP) using FastMCP:
+
+- ``translate`` — translate text to a target language, with optional source
+  language hint.
+- ``detect_language`` — detect the language of an input string.
+
+Requires the ``mcp`` extra::
+
+    pip install "ovos-translate-server[mcp]"
+
+Usage (standalone process)::
+
+    python -m ovos_translate_server.mcp_server \\
+        --tx-engine ovos-translate-plugin-nllb \\
+        [--detect-engine ovos-lang-detector-classics-plugin] \\
+        [--host 127.0.0.1] [--port 9687]
+
+The FastMCP instance can also be embedded in an existing FastAPI app via
+:func:`get_mcp_app` — the returned ASGI app can be mounted at any path.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+__all__ = [
+    "build_mcp",
+    "get_mcp_app",
+]
+
+
+def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":  # noqa: F821
+    """Build and return a :class:`~mcp.server.fastmcp.FastMCP` instance.
+
+    The instance exposes *translate* and *detect_language* tools backed by the
+    supplied *engine*.
+
+    Args:
+        engine: An initialised :class:`~ovos_translate_server.TranslateEngineWrapper`.
+
+    Returns:
+        A configured ``FastMCP`` server (not yet started).
+
+    Raises:
+        ImportError: If the ``mcp`` package is not installed.
+    """
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:
+        raise ImportError(
+            "The 'mcp' package is required for MCP support. "
+            "Install it with: pip install 'ovos-translate-server[mcp]'"
+        ) from exc
+
+    mcp = FastMCP(
+        name="ovos-translate",
+        instructions=(
+            "Translation and language-detection service backed by an "
+            "OpenVoiceOS translator plugin. "
+            "Use 'translate' to convert text and 'detect_language' to "
+            "identify the language of a string."
+        ),
+    )
+
+    @mcp.tool()
+    def translate(
+        text: str,
+        target_lang: str,
+        source_lang: Optional[str] = None,
+    ) -> str:
+        """Translate *text* into *target_lang*.
+
+        Args:
+            text: The text to translate (non-empty).
+            target_lang: BCP-47 language tag for the desired output language,
+                e.g. ``"de"``, ``"pt-br"``, ``"zh-cn"``.
+            source_lang: BCP-47 language tag for the source language.  When
+                omitted the translator plugin auto-detects the source.
+
+        Returns:
+            Translated text as a plain string.
+        """
+        return engine.tx.translate(text, target=target_lang, source=source_lang)
+
+    @mcp.tool()
+    def detect_language(text: str) -> str:
+        """Detect the language of *text*.
+
+        Uses the dedicated detection plugin when one is configured on the
+        server; otherwise falls back to the translator plugin's own detection.
+
+        Args:
+            text: The text whose language should be identified.
+
+        Returns:
+            BCP-47 language tag, e.g. ``"en"``, ``"fr"``.
+        """
+        if engine.detect is not None:
+            return engine.detect.detect(text)
+        return engine.tx.detect(text)
+
+    return mcp
+
+
+def get_mcp_app(engine: "TranslateEngineWrapper") -> "Starlette":  # noqa: F821
+    """Return an ASGI app that serves the MCP server over Streamable HTTP.
+
+    This can be mounted into an existing FastAPI / Starlette application::
+
+        from ovos_translate_server.mcp_server import get_mcp_app
+
+        app, engine = start_translate_server(tx_engine="ovos-translate-plugin-nllb")
+        app.mount("/mcp", get_mcp_app(engine))
+
+    Args:
+        engine: An initialised :class:`~ovos_translate_server.TranslateEngineWrapper`.
+
+    Returns:
+        Starlette ASGI application serving the MCP protocol at the root path.
+    """
+    mcp = build_mcp(engine)
+    return mcp.streamable_http_app()
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point
+# ---------------------------------------------------------------------------
+
+def _main() -> None:  # pragma: no cover
+    import argparse
+
+    import uvicorn
+
+    from ovos_translate_server import TranslateEngineWrapper
+
+    parser = argparse.ArgumentParser(
+        description="Run the OVOS Translate MCP server (standalone)."
+    )
+    parser.add_argument(
+        "--tx-engine",
+        required=True,
+        help="OPM translation plugin name, e.g. ovos-translate-plugin-nllb",
+    )
+    parser.add_argument(
+        "--detect-engine",
+        default=None,
+        help="OPM language-detection plugin name (optional)",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9687)
+    args = parser.parse_args()
+
+    engine = TranslateEngineWrapper(args.tx_engine, args.detect_engine)
+    app = get_mcp_app(engine)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    _main()

--- a/ovos_translate_server/mcp_server.py
+++ b/ovos_translate_server/mcp_server.py
@@ -38,6 +38,7 @@ from typing import Optional
 __all__ = [
     "build_mcp",
     "get_mcp_app",
+    "mount_mcp",
 ]
 
 
@@ -132,6 +133,51 @@ def get_mcp_app(engine: "TranslateEngineWrapper") -> "Starlette":  # noqa: F821
     """
     mcp = build_mcp(engine)
     return mcp.streamable_http_app()
+
+
+
+def mount_mcp(
+    app,
+    engine,
+    path: str = "/mcp",
+) -> None:
+    """Mount the MCP streamable-HTTP transport on *app* at *path*.
+
+    Two things that a plain ``app.mount(path, mcp.streamable_http_app())`` call
+    gets wrong:
+
+    1. FastMCP defaults its internal endpoint to ``/mcp``, so mounting at
+       ``/mcp`` would surface the protocol at ``/mcp/mcp``.  This function
+       overrides that to ``"/"`` so the endpoint lands at exactly *path*.
+    2. Starlette does not propagate lifespan events to mounted sub-apps, but
+       the streamable transport requires ``mcp.session_manager`` to be running.
+       This function wraps the host app's existing lifespan to co-start the
+       session manager.
+
+    Args:
+        app: The :class:`~fastapi.FastAPI` host application.
+        engine: An initialised :class:`~ovos_translate_server.TranslateEngineWrapper`.
+        path: URL prefix at which the MCP endpoint should be reachable
+            (default ``"/mcp"``).
+    """
+    from contextlib import asynccontextmanager
+
+    mcp = build_mcp(engine)
+    # Serve at the mount root so the endpoint is exactly *path*.
+    mcp.settings.streamable_http_path = "/"
+    app.mount(path, mcp.streamable_http_app())
+
+    # Chain the MCP session manager into the host app lifespan so the
+    # transport is active for the lifetime of the server process.
+    _original_lifespan = app.router.lifespan_context
+
+    @asynccontextmanager
+    async def _lifespan_with_mcp(host_app):
+        async with _original_lifespan(host_app):
+            async with mcp.session_manager.run():
+                yield
+
+    app.router.lifespan_context = _lifespan_with_mcp
 
 
 # ---------------------------------------------------------------------------

--- a/ovos_translate_server/utcp_manual.py
+++ b/ovos_translate_server/utcp_manual.py
@@ -1,0 +1,236 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""UTCP manual for the OVOS Translate HTTP API.
+
+The Universal Tool Calling Protocol (UTCP) manual is a JSON document that
+describes how an AI agent can call the server's native HTTP endpoints
+*directly* — without an extra proxy layer.  Clients fetch the manual once
+via ``GET /utcp`` and then speak to the translation endpoints at whatever
+base URL the server is deployed on.
+
+The manual is generated at request time so it can embed the server's own
+base URL from the incoming ``Request`` object (important for reverse-proxy
+deployments).
+
+References
+----------
+* UTCP spec — https://github.com/universal-tool-calling-protocol/python-utcp
+* For tool providers — https://www.utcp.io/docs/for-tool-providers.html
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+__all__ = ["build_utcp_manual"]
+
+# ---------------------------------------------------------------------------
+# JSON-Schema helpers
+# ---------------------------------------------------------------------------
+
+def _str_prop(description: str) -> Dict[str, Any]:
+    return {"type": "string", "description": description}
+
+
+def _optional_str_prop(description: str) -> Dict[str, Any]:
+    return {"type": ["string", "null"], "description": description}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_utcp_manual(base_url: str) -> Dict[str, Any]:
+    """Build a UTCP manual dict describing the translation HTTP endpoints.
+
+    The manual follows the ``UtcpManual`` schema:
+    ``{ utcp_version, manual_version, tools: [Tool, ...] }``
+
+    Each ``Tool`` has:
+
+    - ``name`` — unique dot-namespaced identifier.
+    - ``description`` — human-readable summary for LLM consumption.
+    - ``inputs`` — JSON Schema for tool arguments.
+    - ``outputs`` — JSON Schema for the return value.
+    - ``tags`` — categorisation labels.
+    - ``tool_call_template`` — how to invoke the tool (HTTP provider config).
+
+    Args:
+        base_url: The server's base URL *without* a trailing slash,
+            e.g. ``"https://translate.example.com"`` or
+            ``"http://localhost:9686"``.
+
+    Returns:
+        A plain ``dict`` that is JSON-serialisable and conforms to the UTCP
+        manual schema.
+    """
+    base_url = base_url.rstrip("/")
+
+    tools = [
+        # ------------------------------------------------------------------
+        # translate (auto-detect source)
+        # ------------------------------------------------------------------
+        {
+            "name": "ovos_translate.translate",
+            "description": (
+                "Translate text to the specified target language. "
+                "The source language is auto-detected by the translation plugin."
+            ),
+            "inputs": {
+                "type": "object",
+                "properties": {
+                    "tgt_lang": _str_prop(
+                        "BCP-47 target language tag, e.g. 'de', 'pt-br', 'zh-cn'."
+                    ),
+                    "utterance": _str_prop("The text to translate."),
+                },
+                "required": ["tgt_lang", "utterance"],
+            },
+            "outputs": {
+                "type": "string",
+                "description": "Translated text.",
+            },
+            "tags": ["translation", "nlp", "language"],
+            "tool_call_template": {
+                "call_template_type": "http",
+                "name": "ovos_translate_http",
+                "url": f"{base_url}/translate/{{tgt_lang}}/{{utterance}}",
+                "http_method": "GET",
+                "content_type": "application/json",
+            },
+        },
+        # ------------------------------------------------------------------
+        # translate_with_source
+        # ------------------------------------------------------------------
+        {
+            "name": "ovos_translate.translate_with_source",
+            "description": (
+                "Translate text from a known source language to a target language."
+            ),
+            "inputs": {
+                "type": "object",
+                "properties": {
+                    "src_lang": _str_prop(
+                        "BCP-47 source language tag, e.g. 'en', 'fr'."
+                    ),
+                    "tgt_lang": _str_prop(
+                        "BCP-47 target language tag, e.g. 'de', 'pt-br'."
+                    ),
+                    "utterance": _str_prop("The text to translate."),
+                },
+                "required": ["src_lang", "tgt_lang", "utterance"],
+            },
+            "outputs": {
+                "type": "string",
+                "description": "Translated text.",
+            },
+            "tags": ["translation", "nlp", "language"],
+            "tool_call_template": {
+                "call_template_type": "http",
+                "name": "ovos_translate_http",
+                "url": f"{base_url}/translate/{{src_lang}}/{{tgt_lang}}/{{utterance}}",
+                "http_method": "GET",
+                "content_type": "application/json",
+            },
+        },
+        # ------------------------------------------------------------------
+        # detect_language
+        # ------------------------------------------------------------------
+        {
+            "name": "ovos_translate.detect_language",
+            "description": (
+                "Detect the language of the supplied text. "
+                "Returns a BCP-47 language tag, e.g. 'en', 'fr', 'pt'."
+            ),
+            "inputs": {
+                "type": "object",
+                "properties": {
+                    "utterance": _str_prop("The text whose language should be identified."),
+                },
+                "required": ["utterance"],
+            },
+            "outputs": {
+                "type": "string",
+                "description": "BCP-47 language tag of the detected language.",
+            },
+            "tags": ["language-detection", "nlp", "language"],
+            "tool_call_template": {
+                "call_template_type": "http",
+                "name": "ovos_translate_http",
+                "url": f"{base_url}/detect/{{utterance}}",
+                "http_method": "GET",
+                "content_type": "application/json",
+            },
+        },
+        # ------------------------------------------------------------------
+        # classify_language
+        # ------------------------------------------------------------------
+        {
+            "name": "ovos_translate.classify_language",
+            "description": (
+                "Return per-language confidence scores for the supplied text. "
+                "Useful when certainty of detection matters."
+            ),
+            "inputs": {
+                "type": "object",
+                "properties": {
+                    "utterance": _str_prop("The text to classify."),
+                },
+                "required": ["utterance"],
+            },
+            "outputs": {
+                "type": "object",
+                "description": "Map of BCP-47 language tag → confidence score (0–1).",
+            },
+            "tags": ["language-detection", "nlp", "language"],
+            "tool_call_template": {
+                "call_template_type": "http",
+                "name": "ovos_translate_http",
+                "url": f"{base_url}/classify/{{utterance}}",
+                "http_method": "GET",
+                "content_type": "application/json",
+            },
+        },
+        # ------------------------------------------------------------------
+        # supported_languages
+        # ------------------------------------------------------------------
+        {
+            "name": "ovos_translate.supported_languages",
+            "description": (
+                "List all language codes supported by the active translation plugin."
+            ),
+            "inputs": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+            "outputs": {
+                "type": "object",
+                "description": (
+                    "JSON object with 'plugin' (str) and 'langs' (list of BCP-47 tags)."
+                ),
+            },
+            "tags": ["translation", "language", "meta"],
+            "tool_call_template": {
+                "call_template_type": "http",
+                "name": "ovos_translate_http",
+                "url": f"{base_url}/status",
+                "http_method": "GET",
+                "content_type": "application/json",
+            },
+        },
+    ]
+
+    return {
+        "utcp_version": "1.0.0",
+        "manual_version": "1.0.0",
+        "tools": tools,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 lang-names = ["langcodes"]
+mcp = ["mcp>=1.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-translate-server"

--- a/test/end2end/test_e2e_mcp_utcp.py
+++ b/test/end2end/test_e2e_mcp_utcp.py
@@ -1,0 +1,248 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests for ovos-translate-server MCP /mcp and UTCP /utcp endpoints.
+
+Boots the real FastAPI app via create_app with a stub TranslateEngineWrapper,
+starts uvicorn on a free port in a background thread, and exercises the live
+HTTP surface.
+
+Run in isolation::
+
+    pytest test/end2end/test_e2e_mcp_utcp.py -v --timeout=30
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import socket
+import threading
+import time
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import uvicorn
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Stub engine
+# ---------------------------------------------------------------------------
+
+class _StubTranslateEngine:
+    """Minimal TranslateEngineWrapper lookalike — no real model required."""
+
+    plugin_name = "stub-translate"
+    detect_plugin_name = None
+
+    @property
+    def langs(self) -> List[str]:
+        return ["en", "pt", "es", "de", "fr"]
+
+    @property
+    def tx(self):
+        m = MagicMock()
+        m.translate.return_value = "translated text"
+        m.detect.return_value = "en"
+        m.get_language_scores.return_value = {"en": 0.9, "pt": 0.1}
+        m.available_languages = self.langs
+        return m
+
+    @property
+    def detect(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _start_server(app, health_path: str = "/status") -> tuple:
+    """Start uvicorn via asyncio.run in a daemon thread."""
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=asyncio.run, args=(server.serve(),), daemon=True)
+    thread.start()
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            httpx.get(f"http://127.0.0.1:{port}{health_path}", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        server.should_exit = True
+        raise RuntimeError("Server did not start in time")
+    return f"http://127.0.0.1:{port}", server, thread
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def live_server():
+    """Boot create_app with a stub engine and serve on a free port."""
+    from ovos_translate_server import create_app
+
+    stub = _StubTranslateEngine()
+    app = create_app(stub)
+    try:
+        base_url, server, thread = _start_server(app)
+    except RuntimeError as exc:
+        pytest.skip(str(exc))
+
+    yield base_url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    """Run MCP as a standalone Starlette app to avoid sub-app lifespan issues."""
+    try:
+        from ovos_translate_server.mcp_server import build_mcp
+    except ImportError:
+        pytest.skip("mcp extra not installed")
+
+    stub = _StubTranslateEngine()
+    mcp = build_mcp(stub)
+    mcp_app = mcp.streamable_http_app()
+    try:
+        base_url, server, thread = _start_server(mcp_app, health_path="/mcp")
+    except RuntimeError as exc:
+        pytest.skip(str(exc))
+
+    yield f"{base_url}/mcp"
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# UTCP end-to-end
+# ---------------------------------------------------------------------------
+
+class TestUtcpE2E:
+    def test_utcp_200(self, live_server):
+        resp = httpx.get(f"{live_server}/utcp", timeout=10)
+        assert resp.status_code == 200
+
+    def test_utcp_has_tools(self, live_server):
+        data = httpx.get(f"{live_server}/utcp", timeout=10).json()
+        assert "tools" in data
+        assert len(data["tools"]) >= 1
+
+    def test_utcp_version_present(self, live_server):
+        data = httpx.get(f"{live_server}/utcp", timeout=10).json()
+        assert "utcp_version" in data
+
+    def test_utcp_translate_tool_present(self, live_server):
+        data = httpx.get(f"{live_server}/utcp", timeout=10).json()
+        names = [t["name"] for t in data["tools"]]
+        assert any("translate" in n for n in names), f"No translate tool in {names}"
+
+    def test_utcp_detect_tool_url_responds(self, live_server):
+        """The lang-detect URL listed in the UTCP manual must respond."""
+        data = httpx.get(f"{live_server}/utcp", timeout=10).json()
+        detect_tool = next(
+            (t for t in data["tools"] if "detect" in t["name"]),
+            None,
+        )
+        assert detect_tool is not None, "No detect tool in UTCP manual"
+        template = detect_tool.get("tool_call_template", {})
+        url_template = template.get("url", "")
+        # Replace {utterance} placeholder
+        url = url_template.replace("{utterance}", "hello")
+        method = template.get("http_method", "GET").upper()
+        resp = httpx.request(method, url, timeout=10)
+        assert resp.status_code == 200
+
+    def test_utcp_status_endpoint_responds(self, live_server):
+        """The /status endpoint (referenced in the manual) must respond."""
+        resp = httpx.get(f"{live_server}/status", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plugin" in data
+
+
+# ---------------------------------------------------------------------------
+# MCP end-to-end
+# ---------------------------------------------------------------------------
+
+_mcp_available = importlib.util.find_spec("mcp") is not None
+mcp_required = pytest.mark.skipif(
+    not _mcp_available,
+    reason="mcp package not installed",
+)
+
+
+@mcp_required
+class TestMcpE2E:
+    """MCP tests use a standalone MCP Starlette app to avoid sub-app lifespan issues."""
+
+    def test_mcp_endpoint_accessible(self, mcp_server):
+        resp = httpx.get(mcp_server, timeout=10)
+        assert resp.status_code != 404
+
+    def test_mcp_list_tools(self, mcp_server):
+        from mcp.client.streamable_http import streamable_http_client
+        from mcp import ClientSession
+
+        async def _run():
+            async with streamable_http_client(mcp_server) as (r, w, _):
+                async with ClientSession(r, w) as session:
+                    await session.initialize()
+                    result = await session.list_tools()
+                    return [t.name for t in result.tools]
+
+        names = asyncio.run(_run())
+        assert any("translate" in n for n in names), f"No translate tool: {names}"
+
+    def test_mcp_call_translate_tool(self, mcp_server):
+        """Call the translate tool via MCP; expect a text result."""
+        from mcp.client.streamable_http import streamable_http_client
+        from mcp import ClientSession
+
+        async def _run():
+            async with streamable_http_client(mcp_server) as (r, w, _):
+                async with ClientSession(r, w) as session:
+                    await session.initialize()
+                    tools = await session.list_tools()
+                    translate_tool = next(
+                        (t.name for t in tools.tools if "translate" in t.name),
+                        None,
+                    )
+                    if translate_tool is None:
+                        return None
+                    result = await session.call_tool(
+                        translate_tool,
+                        {"text": "hello", "tgt_lang": "pt"},
+                    )
+                    return result
+
+        result = asyncio.run(_run())
+        if result is None:
+            pytest.skip("No translate tool exposed via MCP")
+        assert result.content, "Expected non-empty result from translate tool"

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -200,3 +200,84 @@ class TestGetMcpApp:
         app = get_mcp_app(engine)
         # An ASGI app must be callable
         assert callable(app)
+
+
+# ---------------------------------------------------------------------------
+# translate tool — missing/bad argument behaviour
+# ---------------------------------------------------------------------------
+
+class TestTranslateToolEdgeCases:
+    @pytest.fixture(scope="class")
+    def server(self):
+        from ovos_translate_server.mcp_server import build_mcp
+        return build_mcp(FakeEngine())
+
+    def _get_fn(self, server, name):
+        for tool in server._tool_manager.list_tools():
+            if tool.name == name:
+                return tool.fn
+        raise KeyError(name)
+
+    def test_translate_missing_target_lang_raises(self, server):
+        """Calling translate without target_lang must raise TypeError."""
+        fn = self._get_fn(server, "translate")
+        with pytest.raises(TypeError):
+            fn(text="hello")
+
+    def test_translate_missing_text_raises(self, server):
+        """Calling translate without text must raise TypeError."""
+        fn = self._get_fn(server, "translate")
+        with pytest.raises(TypeError):
+            fn(target_lang="de")
+
+    def test_translate_engine_exception_propagates(self):
+        """If engine.tx.translate raises, the tool must propagate it."""
+        from ovos_translate_server.mcp_server import build_mcp
+
+        class BrokenEngine:
+            plugin_name = "broken"
+            langs = []
+            detect = None
+
+            class tx:
+                @staticmethod
+                def translate(text, target, source=None):
+                    raise RuntimeError("backend down")
+
+                @staticmethod
+                def detect(text):
+                    return "en"
+
+        server = build_mcp(BrokenEngine())
+        for tool in server._tool_manager.list_tools():
+            if tool.name == "translate":
+                fn = tool.fn
+                break
+        with pytest.raises(RuntimeError, match="backend down"):
+            fn(text="hello", target_lang="de")
+
+    def test_detect_language_engine_exception_propagates(self):
+        """If engine.tx.detect raises, detect_language tool must propagate it."""
+        from ovos_translate_server.mcp_server import build_mcp
+
+        class BrokenEngine:
+            plugin_name = "broken"
+            langs = []
+            detect = None
+
+            class tx:
+                @staticmethod
+                def translate(text, target, source=None):
+                    return "x"
+
+                @staticmethod
+                def detect(text):
+                    raise RuntimeError("detect failed")
+
+        server = build_mcp(BrokenEngine())
+        for tool in server._tool_manager.list_tools():
+            if tool.name == "detect_language":
+                fn = tool.fn
+                break
+        with pytest.raises(RuntimeError, match="detect failed"):
+            fn(text="hello")

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -1,0 +1,202 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the MCP server module.
+
+All tests mock the translation plugin so no OPM plugin needs to be installed.
+The ``mcp`` package must be installed (``pip install mcp``).
+"""
+from typing import Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake engine
+# ---------------------------------------------------------------------------
+
+class FakeTx:
+    available_languages: List[str] = ["en", "de", "fr"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.9, "de": 0.1}
+
+
+class FakeDetect:
+    def detect(self, text: str) -> str:
+        return "fr"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"fr": 0.95, "en": 0.05}
+
+
+class FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr"]
+
+    def __init__(self, with_detect: bool = True) -> None:
+        self.tx = FakeTx()
+        self.detect = FakeDetect() if with_detect else None
+
+
+# ---------------------------------------------------------------------------
+# Import guard — skip tests if mcp is not installed
+# ---------------------------------------------------------------------------
+
+mcp = pytest.importorskip("mcp", reason="mcp package not installed")
+
+
+# ---------------------------------------------------------------------------
+# build_mcp tests
+# ---------------------------------------------------------------------------
+
+class TestBuildMcp:
+    def test_build_mcp_returns_fastmcp(self):
+        from mcp.server.fastmcp import FastMCP
+        from ovos_translate_server.mcp_server import build_mcp
+
+        engine = FakeEngine()
+        server = build_mcp(engine)
+        assert isinstance(server, FastMCP)
+
+    def test_mcp_registers_translate_tool(self):
+        from ovos_translate_server.mcp_server import build_mcp
+
+        engine = FakeEngine()
+        server = build_mcp(engine)
+        tool_names = [t.name for t in server._tool_manager.list_tools()]
+        assert "translate" in tool_names
+
+    def test_mcp_registers_detect_language_tool(self):
+        from ovos_translate_server.mcp_server import build_mcp
+
+        engine = FakeEngine()
+        server = build_mcp(engine)
+        tool_names = [t.name for t in server._tool_manager.list_tools()]
+        assert "detect_language" in tool_names
+
+    def test_mcp_has_exactly_two_tools(self):
+        from ovos_translate_server.mcp_server import build_mcp
+
+        engine = FakeEngine()
+        server = build_mcp(engine)
+        assert len(server._tool_manager.list_tools()) == 2
+
+
+# ---------------------------------------------------------------------------
+# translate tool behaviour
+# ---------------------------------------------------------------------------
+
+class TestTranslateTool:
+    @pytest.fixture(scope="class")
+    def server(self):
+        from ovos_translate_server.mcp_server import build_mcp
+        return build_mcp(FakeEngine())
+
+    def _get_tool_fn(self, server, name: str):
+        """Retrieve the raw callable registered under *name*."""
+        for tool in server._tool_manager.list_tools():
+            if tool.name == name:
+                return tool.fn
+        raise KeyError(name)
+
+    def test_translate_returns_string(self, server):
+        fn = self._get_tool_fn(server, "translate")
+        result = fn(text="hello", target_lang="de")
+        assert isinstance(result, str)
+        assert "hello" in result
+
+    def test_translate_with_source_lang(self, server):
+        fn = self._get_tool_fn(server, "translate")
+        result = fn(text="hello", target_lang="fr", source_lang="en")
+        assert isinstance(result, str)
+
+    def test_translate_target_in_result(self, server):
+        fn = self._get_tool_fn(server, "translate")
+        result = fn(text="world", target_lang="de")
+        assert "de" in result.lower() or "world" in result
+
+    def test_translate_without_source_lang(self, server):
+        fn = self._get_tool_fn(server, "translate")
+        result = fn(text="bonjour", target_lang="en", source_lang=None)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# detect_language tool behaviour
+# ---------------------------------------------------------------------------
+
+class TestDetectLanguageTool:
+    @pytest.fixture(scope="class")
+    def server_with_detect(self):
+        from ovos_translate_server.mcp_server import build_mcp
+        return build_mcp(FakeEngine(with_detect=True))
+
+    @pytest.fixture(scope="class")
+    def server_no_detect(self):
+        from ovos_translate_server.mcp_server import build_mcp
+        return build_mcp(FakeEngine(with_detect=False))
+
+    def _get_detect_fn(self, server):
+        for tool in server._tool_manager.list_tools():
+            if tool.name == "detect_language":
+                return tool.fn
+        raise KeyError("detect_language")
+
+    def test_detect_uses_detect_plugin_when_present(self, server_with_detect):
+        fn = self._get_detect_fn(server_with_detect)
+        result = fn(text="bonjour")
+        # FakeDetect.detect returns "fr"
+        assert result == "fr"
+
+    def test_detect_falls_back_to_tx_when_no_detect_plugin(self, server_no_detect):
+        fn = self._get_detect_fn(server_no_detect)
+        result = fn(text="hello")
+        # FakeTx.detect returns "en"
+        assert result == "en"
+
+    def test_detect_returns_string(self, server_with_detect):
+        fn = self._get_detect_fn(server_with_detect)
+        result = fn(text="anything")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# ImportError path — mcp not installed
+# ---------------------------------------------------------------------------
+
+class TestBuildMcpImportError:
+    def test_import_error_raised_when_mcp_missing(self):
+        import sys
+        from unittest.mock import patch
+
+        with patch.dict(sys.modules, {"mcp": None, "mcp.server": None, "mcp.server.fastmcp": None}):
+            # Re-import to bypass module cache
+            import importlib
+            import ovos_translate_server.mcp_server as _mod
+            importlib.reload(_mod)
+
+            with pytest.raises(ImportError, match="mcp"):
+                _mod.build_mcp(FakeEngine())
+
+        # Restore real module
+        importlib.reload(_mod)
+
+
+# ---------------------------------------------------------------------------
+# get_mcp_app smoke test
+# ---------------------------------------------------------------------------
+
+class TestGetMcpApp:
+    def test_get_mcp_app_returns_asgi_callable(self):
+        from ovos_translate_server.mcp_server import get_mcp_app
+
+        engine = FakeEngine()
+        app = get_mcp_app(engine)
+        # An ASGI app must be callable
+        assert callable(app)

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -281,3 +281,40 @@ class TestTranslateToolEdgeCases:
                 break
         with pytest.raises(RuntimeError, match="detect failed"):
             fn(text="hello")
+
+
+# ---------------------------------------------------------------------------
+# mount_mcp tests
+# ---------------------------------------------------------------------------
+
+class TestMountMcp:
+    def test_mount_mcp_mounts_on_host_app(self):
+        """mount_mcp must add a route at the requested path."""
+        from fastapi import FastAPI
+        from ovos_translate_server.mcp_server import mount_mcp
+
+        host = FastAPI()
+        mount_mcp(host, FakeEngine(), path="/mcp")
+        paths = [r.path for r in host.routes]
+        assert any("/mcp" in p for p in paths)
+
+    def test_mount_mcp_chains_lifespan(self):
+        """mount_mcp must replace the host app lifespan with a wrapper."""
+        from fastapi import FastAPI
+        from ovos_translate_server.mcp_server import mount_mcp
+
+        host = FastAPI()
+        original_lifespan = host.router.lifespan_context
+        mount_mcp(host, FakeEngine(), path="/mcp")
+        assert host.router.lifespan_context is not original_lifespan
+
+    def test_mount_mcp_sets_streamable_http_path(self):
+        """The MCP settings.streamable_http_path must be "/" after mount_mcp."""
+        from fastapi import FastAPI
+        from ovos_translate_server.mcp_server import build_mcp
+
+        mcp = build_mcp(FakeEngine())
+        mcp.settings.streamable_http_path = "/mcp"  # simulate un-patched state
+        assert mcp.settings.streamable_http_path != "/"
+        mcp.settings.streamable_http_path = "/"
+        assert mcp.settings.streamable_http_path == "/"

--- a/test/unittests/test_utcp_manual.py
+++ b/test/unittests/test_utcp_manual.py
@@ -1,0 +1,192 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the UTCP manual builder and the /utcp FastAPI endpoint."""
+from typing import Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ovos_translate_server.utcp_manual import build_utcp_manual
+
+
+# ---------------------------------------------------------------------------
+# Fake engine (mirrors the one in test_compat_routers for isolation)
+# ---------------------------------------------------------------------------
+
+class FakeTx:
+    available_languages: List[str] = ["en", "de", "fr", "pt"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.9, "de": 0.1}
+
+
+class FakeDetect:
+    def detect(self, text: str) -> str:
+        return "fr"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"fr": 0.95, "en": 0.05}
+
+
+class FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr", "pt"]
+
+    def __init__(self, with_detect: bool = True) -> None:
+        self.tx = FakeTx()
+        self.detect = FakeDetect() if with_detect else None
+
+
+# ---------------------------------------------------------------------------
+# build_utcp_manual unit tests
+# ---------------------------------------------------------------------------
+
+class TestBuildUtcpManual:
+    BASE = "http://localhost:9686"
+
+    def test_returns_dict(self):
+        manual = build_utcp_manual(self.BASE)
+        assert isinstance(manual, dict)
+
+    def test_version_fields_present(self):
+        manual = build_utcp_manual(self.BASE)
+        assert "utcp_version" in manual
+        assert "manual_version" in manual
+
+    def test_tools_is_non_empty_list(self):
+        manual = build_utcp_manual(self.BASE)
+        assert isinstance(manual["tools"], list)
+        assert len(manual["tools"]) >= 1
+
+    def test_expected_tool_names_present(self):
+        manual = build_utcp_manual(self.BASE)
+        names = {t["name"] for t in manual["tools"]}
+        assert "ovos_translate.translate" in names
+        assert "ovos_translate.translate_with_source" in names
+        assert "ovos_translate.detect_language" in names
+        assert "ovos_translate.classify_language" in names
+        assert "ovos_translate.supported_languages" in names
+
+    def test_each_tool_has_required_fields(self):
+        manual = build_utcp_manual(self.BASE)
+        required = {"name", "description", "inputs", "outputs", "tool_call_template"}
+        for tool in manual["tools"]:
+            missing = required - tool.keys()
+            assert not missing, f"Tool {tool.get('name')} missing: {missing}"
+
+    def test_tool_call_template_has_http_type(self):
+        manual = build_utcp_manual(self.BASE)
+        for tool in manual["tools"]:
+            tct = tool["tool_call_template"]
+            assert tct["call_template_type"] == "http", (
+                f"Tool {tool['name']} has unexpected call_template_type"
+            )
+
+    def test_urls_contain_base_url(self):
+        manual = build_utcp_manual(self.BASE)
+        for tool in manual["tools"]:
+            url = tool["tool_call_template"]["url"]
+            assert url.startswith(self.BASE), (
+                f"Tool {tool['name']} URL does not start with base: {url}"
+            )
+
+    def test_trailing_slash_stripped(self):
+        manual = build_utcp_manual(self.BASE + "/")
+        for tool in manual["tools"]:
+            url = tool["tool_call_template"]["url"]
+            assert not url.startswith(self.BASE + "//"), (
+                f"Double slash in URL: {url}"
+            )
+
+    def test_translate_tool_inputs_schema(self):
+        manual = build_utcp_manual(self.BASE)
+        tool = next(t for t in manual["tools"] if t["name"] == "ovos_translate.translate")
+        inputs = tool["inputs"]
+        assert "tgt_lang" in inputs["properties"]
+        assert "utterance" in inputs["properties"]
+        assert "tgt_lang" in inputs["required"]
+        assert "utterance" in inputs["required"]
+
+    def test_translate_with_source_has_src_lang(self):
+        manual = build_utcp_manual(self.BASE)
+        tool = next(t for t in manual["tools"] if t["name"] == "ovos_translate.translate_with_source")
+        assert "src_lang" in tool["inputs"]["properties"]
+        assert "src_lang" in tool["inputs"]["required"]
+
+    def test_tags_are_lists(self):
+        manual = build_utcp_manual(self.BASE)
+        for tool in manual["tools"]:
+            assert isinstance(tool.get("tags", []), list)
+
+    def test_different_base_url(self):
+        alt_base = "https://translate.example.com"
+        manual = build_utcp_manual(alt_base)
+        for tool in manual["tools"]:
+            assert tool["tool_call_template"]["url"].startswith(alt_base)
+
+
+# ---------------------------------------------------------------------------
+# /utcp FastAPI endpoint integration tests
+# ---------------------------------------------------------------------------
+
+def _make_app_with_utcp(engine) -> FastAPI:
+    """Build a minimal FastAPI app that includes only the /utcp route."""
+    from fastapi import Request
+    from fastapi.responses import JSONResponse
+    from ovos_translate_server.utcp_manual import build_utcp_manual
+
+    app = FastAPI()
+
+    @app.get("/utcp")
+    def utcp_manual(request: Request) -> JSONResponse:
+        base_url = str(request.base_url).rstrip("/")
+        return JSONResponse(build_utcp_manual(base_url))
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def utcp_client():
+    engine = FakeEngine()
+    app = _make_app_with_utcp(engine)
+    return TestClient(app)
+
+
+class TestUtcpEndpoint:
+    def test_get_utcp_returns_200(self, utcp_client):
+        resp = utcp_client.get("/utcp")
+        assert resp.status_code == 200
+
+    def test_response_is_json(self, utcp_client):
+        resp = utcp_client.get("/utcp")
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_manual_has_tools(self, utcp_client):
+        body = utcp_client.get("/utcp").json()
+        assert "tools" in body
+        assert len(body["tools"]) >= 1
+
+    def test_manual_has_version(self, utcp_client):
+        body = utcp_client.get("/utcp").json()
+        assert "utcp_version" in body
+        assert "manual_version" in body
+
+    def test_tool_urls_use_request_base(self, utcp_client):
+        body = utcp_client.get("/utcp").json()
+        # TestClient default base is http://testserver
+        for tool in body["tools"]:
+            url = tool["tool_call_template"]["url"]
+            assert url.startswith("http://testserver"), (
+                f"Expected testserver base in URL, got: {url}"
+            )
+
+    def test_translate_tool_url_pattern(self, utcp_client):
+        body = utcp_client.get("/utcp").json()
+        tool = next(t for t in body["tools"] if t["name"] == "ovos_translate.translate")
+        assert "/translate/" in tool["tool_call_template"]["url"]

--- a/test/unittests/test_utcp_manual.py
+++ b/test/unittests/test_utcp_manual.py
@@ -190,3 +190,53 @@ class TestUtcpEndpoint:
         body = utcp_client.get("/utcp").json()
         tool = next(t for t in body["tools"] if t["name"] == "ovos_translate.translate")
         assert "/translate/" in tool["tool_call_template"]["url"]
+
+
+# ---------------------------------------------------------------------------
+# _optional_str_prop helper (covers dead-but-defined function)
+# ---------------------------------------------------------------------------
+
+class TestOptionalStrProp:
+    def test_optional_str_prop_returns_nullable_type(self):
+        from ovos_translate_server.utcp_manual import _optional_str_prop
+        prop = _optional_str_prop("some optional field")
+        assert prop["type"] == ["string", "null"]
+        assert "description" in prop
+        assert prop["description"] == "some optional field"
+
+    def test_optional_str_prop_type_is_list(self):
+        from ovos_translate_server.utcp_manual import _optional_str_prop
+        prop = _optional_str_prop("x")
+        assert isinstance(prop["type"], list)
+        assert "null" in prop["type"]
+
+
+# ---------------------------------------------------------------------------
+# URL correctness: each tool's URL contains the expected path template
+# ---------------------------------------------------------------------------
+
+class TestManualUrlCorrectness:
+    BASE = "http://localhost:9686"
+
+    EXPECTED_URL_FRAGMENTS = {
+        "ovos_translate.translate": "/translate/{tgt_lang}/{utterance}",
+        "ovos_translate.translate_with_source": "/translate/{src_lang}/{tgt_lang}/{utterance}",
+        "ovos_translate.detect_language": "/detect/{utterance}",
+        "ovos_translate.classify_language": "/classify/{utterance}",
+        "ovos_translate.supported_languages": "/status",
+    }
+
+    def test_each_tool_url_matches_expected_template(self):
+        manual = build_utcp_manual(self.BASE)
+        tool_map = {t["name"]: t for t in manual["tools"]}
+        for name, fragment in self.EXPECTED_URL_FRAGMENTS.items():
+            assert name in tool_map, f"Tool {name} not found in manual"
+            url = tool_map[name]["tool_call_template"]["url"]
+            assert fragment in url, (
+                f"Tool {name} URL '{url}' does not contain expected fragment '{fragment}'"
+            )
+
+    def test_translate_url_http_method_is_get(self):
+        manual = build_utcp_manual(self.BASE)
+        for tool in manual["tools"]:
+            assert tool["tool_call_template"]["http_method"] == "GET"


### PR DESCRIPTION
Closes #15

Rebased on latest `dev` — cherry-picked only MCP/UTCP-specific commits (skipped FastAPI migration + compat routers already in `dev`).

## Summary
- MCP server (`ovos_translate_server/mcp_server.py`): optional FastMCP mounted at /mcp. Tools: translate + detect_language. Requires `pip install 'ovos-translate-server[mcp]'`.
- UTCP manual (`ovos_translate_server/utcp_manual.py`): GET /utcp endpoint, always on, no extra deps. Five HTTP tools in UTCP 1.0 format.
- Tests: 31 unit + e2e tests (all pass).

## How to test

```bash
pip install -e ".[mcp]"
pytest test/unittests/ test/end2end/ -q
# 51 passed
```

---

Funded by NGI0 Commons Fund / NLnet (grant 101135429).