### PR TITLE
docs: add API compatibility, language-codes, and detection docs

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,0 +1,233 @@
+# API Compatibility — `ovos-translate-server`
+
+`ovos-translate-server` exposes five vendor-compatible routers so that existing clients written for LibreTranslate, DeepL, Google Cloud Translation, Azure Translator, or Amazon Translate can point at this server with minimal or no code changes.
+
+---
+
+## Why Vendor Prefixes?
+
+LibreTranslate and Azure Translator both define `/translate`, `/detect`, and `/languages` at the root level. If all five routers were mounted without a prefix in the same FastAPI app, the last-registered router would silently shadow the earlier ones — resulting in some vendors' endpoints being unreachable.
+
+Every router is therefore mounted under a unique vendor prefix:
+
+| Vendor | Prefix |
+|--------|--------|
+| LibreTranslate | `/libretranslate` |
+| DeepL | `/deepl` |
+| Google Cloud Translation v2 | `/google` |
+| Azure Translator v3 | `/azure` |
+| Amazon Translate | `/amazon` |
+
+Without these prefixes, `/translate` would be registered five times and only the last registration would be reachable.
+
+---
+
+## Endpoint Reference
+
+| Vendor | Method | Path | Auth Header | Lang Code Format | Notes |
+|--------|--------|------|-------------|-----------------|-------|
+| LibreTranslate | POST | `/libretranslate/translate` | `api_key` body field (ignored) | lowercase BCP-47 | `source="auto"` triggers auto-detect |
+| LibreTranslate | POST | `/libretranslate/detect` | `api_key` body field (ignored) | lowercase BCP-47 | Returns list sorted by confidence desc |
+| LibreTranslate | GET | `/libretranslate/languages` | — | lowercase BCP-47 | Returns `{code, name}` list |
+| DeepL | POST | `/deepl/v2/translate` | `Authorization: DeepL-Auth-Key …` (ignored) | uppercase BCP-47 e.g. `EN-US` | Accepts/returns uppercase; normalised internally |
+| Google | POST | `/google/language/translate/v2` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | `q` may be string or list |
+| Google | POST | `/google/language/translate/v2/detect` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | `q` may be string or list |
+| Google | GET | `/google/language/translate/v2/languages` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | Optional `target` query param accepted |
+| Azure | POST | `/azure/translate` | `Ocp-Apim-Subscription-Key` header (ignored) | BCP-47 | `to` and `from` are query params; `to` can be comma-separated |
+| Azure | POST | `/azure/detect` | `Ocp-Apim-Subscription-Key` header (ignored) | BCP-47 | Body is JSON array of `{"Text": "…"}` items |
+| Azure | GET | `/azure/languages` | — | BCP-47 | `api-version` query param accepted |
+| Amazon | POST | `/amazon/translate/text` | `Authorization` (AWS SigV4, ignored) | BCP-47 | `SourceLanguageCode: "auto"` triggers auto-detect |
+| Amazon | GET | `/amazon/translate/languages` | `Authorization` (ignored) | BCP-47 | Returns `{Languages: [{LanguageCode, LanguageName}]}` |
+
+---
+
+## Curl Examples
+
+### LibreTranslate — Translate
+
+```bash
+curl -s -X POST http://localhost:9686/libretranslate/translate \
+  -H 'Content-Type: application/json' \
+  -d '{"q": "Hello world", "source": "en", "target": "de"}'
+# {"translatedText": "Hallo Welt"}
+```
+
+### LibreTranslate — Detect
+
+```bash
+curl -s -X POST http://localhost:9686/libretranslate/detect \
+  -H 'Content-Type: application/json' \
+  -d '{"q": "Bonjour le monde"}'
+# [{"language": "fr", "confidence": 0.97}, {"language": "en", "confidence": 0.02}]
+```
+
+### LibreTranslate — Languages
+
+```bash
+curl -s http://localhost:9686/libretranslate/languages
+# [{"code": "en", "name": "English"}, {"code": "de", "name": "German"}, ...]
+```
+
+### DeepL — Translate
+
+```bash
+curl -s -X POST http://localhost:9686/deepl/v2/translate \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: DeepL-Auth-Key dummy-key' \
+  -d '{"text": ["Hello world"], "target_lang": "DE"}'
+# {"translations": [{"detected_source_language": "EN", "text": "Hallo Welt"}]}
+```
+
+### Google Cloud Translation — Translate
+
+```bash
+curl -s -X POST http://localhost:9686/google/language/translate/v2 \
+  -H 'Content-Type: application/json' \
+  -d '{"q": "Hello world", "target": "fr"}'
+# {"data": {"translations": [{"translatedText": "Bonjour le monde", "detectedSourceLanguage": "en"}]}}
+```
+
+### Google Cloud Translation — Detect
+
+```bash
+curl -s -X POST http://localhost:9686/google/language/translate/v2/detect \
+  -H 'Content-Type: application/json' \
+  -d '{"q": "Bonjour le monde"}'
+# {"data": {"detections": [[{"language": "fr", "confidence": 0.97, "isReliable": false}]]}}
+```
+
+### Google Cloud Translation — Languages
+
+```bash
+curl -s 'http://localhost:9686/google/language/translate/v2/languages?target=en'
+# {"data": {"languages": [{"language": "en"}, {"language": "de"}, ...]}}
+```
+
+### Azure Translator — Translate
+
+```bash
+curl -s -X POST 'http://localhost:9686/azure/translate?to=de&api-version=3.0' \
+  -H 'Content-Type: application/json' \
+  -H 'Ocp-Apim-Subscription-Key: dummy-key' \
+  -d '[{"Text": "Hello world"}]'
+# [{"detectedLanguage": {"language": "en", "score": 0.95}, "translations": [{"text": "Hallo Welt", "to": "DE"}]}]
+```
+
+### Azure Translator — Detect
+
+```bash
+curl -s -X POST 'http://localhost:9686/azure/detect?api-version=3.0' \
+  -H 'Content-Type: application/json' \
+  -d '[{"Text": "Hallo Welt"}]'
+# [{"language": "de", "score": 0.97, "isTranslationSupported": true, "isTransliterationSupported": false}]
+```
+
+### Azure Translator — Languages
+
+```bash
+curl -s 'http://localhost:9686/azure/languages?api-version=3.0'
+# {"translation": {"en": {"name": "English", "nativeName": "English", "dir": "ltr"}, ...}}
+```
+
+### Amazon Translate — Translate Text
+
+```bash
+curl -s -X POST http://localhost:9686/amazon/translate/text \
+  -H 'Content-Type: application/json' \
+  -d '{"Text": "Hello world", "SourceLanguageCode": "en", "TargetLanguageCode": "de"}'
+# {"TranslatedText": "Hallo Welt", "SourceLanguageCode": "en", "TargetLanguageCode": "de"}
+```
+
+### Amazon Translate — List Languages
+
+```bash
+curl -s http://localhost:9686/amazon/translate/languages
+# {"Languages": [{"LanguageCode": "en", "LanguageName": "English"}, ...]}
+```
+
+---
+
+## Path-Conflict Problem — Detailed Explanation
+
+Consider these two real vendor APIs:
+
+- **LibreTranslate**: `POST /translate`, `POST /detect`, `GET /languages`
+- **Azure Translator**: `POST /translate`, `POST /detect`, `GET /languages`
+
+Both define identical paths. FastAPI `include_router` adds routes to a shared route table in registration order. The second router's routes would shadow the first's because FastAPI matches the first registered route that fits. The result: Azure routes would be unreachable (registered second) or LibreTranslate routes would be unreachable depending on order — either way, half the API is broken.
+
+The solution implemented in `create_app()` — `ovos_translate_server/__init__.py:88` — is to mount every router with a unique prefix:
+
+```python
+app.include_router(make_libretranslate_router(engine))   # prefix="/libretranslate"
+app.include_router(make_deepl_router(engine))             # prefix="/deepl"
+app.include_router(make_google_translate_router(engine))  # prefix="/google"
+app.include_router(make_azure_translator_router(engine))  # prefix="/azure"
+app.include_router(make_amazon_translate_router(engine))  # prefix="/amazon"
+```
+
+Each `make_*_router()` factory sets the prefix on the `APIRouter` it returns, so the prefix is co-located with the router definition and cannot be accidentally omitted.
+
+---
+
+## Pointing Existing Clients at This Server
+
+### LibreTranslate Python client
+
+```python
+import libretranslatepy
+lt = libretranslatepy.LibreTranslateAPI("http://localhost:9686/libretranslate/")
+result = lt.translate("Hello", "en", "de")
+```
+
+### DeepL Python client
+
+The official `deepl` library uses `https://api.deepl.com` as the server URL. Pass a custom `server_url`:
+
+```python
+import deepl
+translator = deepl.Translator("dummy-key", server_url="http://localhost:9686/deepl")
+result = translator.translate_text("Hello world", target_lang="DE")
+```
+
+### Google Cloud Translation client
+
+Most Google clients accept a `client_options` argument with a custom API endpoint:
+
+```python
+from google.cloud import translate_v2 as translate
+from google.api_core.client_options import ClientOptions
+
+client = translate.Client(
+    client_options=ClientOptions(api_endpoint="http://localhost:9686/google")
+)
+result = client.translate("Hello world", target_language="de")
+```
+
+### Azure SDK
+
+Configure the `endpoint` when creating the `TextTranslationClient`:
+
+```python
+from azure.ai.translation.text import TextTranslationClient
+from azure.core.credentials import AzureKeyCredential
+
+client = TextTranslationClient(
+    endpoint="http://localhost:9686/azure",
+    credential=AzureKeyCredential("dummy-key"),
+)
+```
+
+### Amazon Translate boto3 client
+
+```python
+import boto3
+client = boto3.client(
+    "translate",
+    endpoint_url="http://localhost:9686/amazon",
+    region_name="us-east-1",
+    aws_access_key_id="dummy",
+    aws_secret_access_key="dummy",
+)
+result = client.translate_text(Text="Hello world", SourceLanguageCode="en", TargetLanguageCode="de")
+```

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -1,0 +1,70 @@
+# Language Detection
+
+`ovos-translate-server` exposes language detection through both the native API and all five vendor-compatible routers. This document explains how detection works internally.
+
+---
+
+## Plugin Priority
+
+Detection is provided by one of two sources, checked in order:
+
+1. **Dedicated detection plugin** — loaded when `--detect-engine` is passed on the CLI (or `detect_engine` is passed to `start_translate_server()`). Uses `engine.detect.detect()` / `engine.detect.detect_probs()`.
+2. **Translator fallback** — when no detection plugin is loaded, `engine.tx.detect()` / `engine.tx.detect_probs()` are called on the translator instance.
+
+Source: `ovos_translate_server/__init__.py:113–115`
+
+```python
+if engine.detect is not None:
+    return engine.detect.detect(utterance)
+return engine.tx.detect(utterance)
+```
+
+---
+
+## Native Detection Endpoints
+
+### `GET /detect/{utterance}` — `ovos_translate_server/__init__.py:107`
+
+Returns a single language code string (e.g. `"en"`, `"fr"`).
+
+### `GET /classify/{utterance}` — `ovos_translate_server/__init__.py:117`
+
+Returns a dict of `{lang_code: confidence_float}` covering all candidate languages. Uses `detect_probs()`.
+
+---
+
+## Detection in Compat Routers
+
+Each vendor router calls detection slightly differently to match the vendor's response shape:
+
+| Router | Detection method used | Response field |
+|--------|-----------------------|----------------|
+| LibreTranslate `/detect` | `detect_probs()` | Sorted list of `{language, confidence}` |
+| DeepL `/v2/translate` | `detect()` (per text item) | `detected_source_language` (uppercase) |
+| Google `/v2/detect` | `detect_probs()` (best result) | `detections[i][0].language` + `confidence` |
+| Google `/v2/translate` | `detect_probs()` (when `source` omitted) | `detectedSourceLanguage` on each translation |
+| Azure `/translate` | `detect_probs()` (when `from` omitted) | `detectedLanguage.language` + `score` |
+| Azure `/detect` | `detect_probs()` | `language` + `score` per item |
+| Amazon `/translate/text` | `detect()` (when `SourceLanguageCode: "auto"`) | `SourceLanguageCode` in response |
+
+---
+
+## Detection Plugin Interface
+
+Any plugin that implements `LanguageDetector` from `ovos_plugin_manager.templates.language` can be used:
+
+```python
+class LanguageDetector:
+    def detect(self, text: str) -> str: ...
+    def detect_probs(self, text: str) -> dict: ...  # {lang_code: float}
+```
+
+The `detect_probs()` method must return a dict. If the plugin does not implement it, all compat routers that call `detect_probs()` will raise an `AttributeError` — this is a known gap (see `AUDIT.md`).
+
+---
+
+## Without a Detection Plugin
+
+When only `--tx-engine` is provided, all detection falls back to the translator's `detect()` and `detect_probs()` methods. Most OVOS translators implement basic detection internally; however, accuracy is typically lower than a dedicated detector.
+
+To get best detection accuracy, always pass `--detect-engine ovos-lang-detector-classics-plugin` (or another dedicated detector).

--- a/docs/language-codes.md
+++ b/docs/language-codes.md
@@ -1,0 +1,78 @@
+# Language Code Normalisation
+
+Each vendor API has its own convention for language code format. `ovos-translate-server` normalises codes at the router boundary so the underlying OVOS plugin always receives BCP-47 lowercase codes (e.g. `en`, `de`, `fr`, `en-us`).
+
+---
+
+## Per-Vendor Conventions
+
+| Vendor | Inbound format | Example inbound | Outbound format | Example outbound |
+|--------|---------------|----------------|-----------------|-----------------|
+| LibreTranslate | lowercase BCP-47 | `en`, `de` | lowercase BCP-47 | `en`, `de` |
+| DeepL | uppercase BCP-47 | `EN`, `EN-US`, `DE` | uppercase BCP-47 | `EN`, `EN-US` |
+| Google | lowercase BCP-47 | `en`, `de`, `en-us` | lowercase BCP-47 | `en`, `de` |
+| Azure | mixed BCP-47 | `en`, `de`, `en-US` | target code echoed unchanged | `de` |
+| Amazon | lowercase BCP-47 | `en`, `de`, `auto` | lowercase BCP-47 | `en`, `de` |
+
+---
+
+## DeepL Normalisation — `routers/deepl.py`
+
+DeepL clients send uppercase codes such as `EN-US` or `DE`. The router converts inbound codes to lowercase before passing them to the plugin, and converts detected/source codes back to uppercase in the response.
+
+```python
+# deepl.py — make_deepl_router / translate handler
+source = request.source_lang.lower() if request.source_lang else None
+target = request.target_lang.lower()
+# ...
+detected_source = engine.detect.detect(item).upper()
+```
+
+- `source_lang` (e.g. `EN`) → lowercased to `en` before calling `engine.tx.translate()`
+- `target_lang` (e.g. `DE`) → lowercased to `de`
+- `detected_source_language` in the response is always uppercased (e.g. `EN`)
+
+Source: `ovos_translate_server/routers/deepl.py:57–71`
+
+---
+
+## Azure Normalisation — `routers/azure_translator.py`
+
+Azure uses the `to` query parameter and an optional `from` parameter. Target codes are echoed back in the `to` field of each translation result. The router uppercases the `to` value in the response to match Azure's behaviour:
+
+```python
+# azure_translator.py — translate handler
+translations.append(AzureTranslation(text=translated or "", to=tgt.upper()))
+```
+
+Source: `ovos_translate_server/routers/azure_translator.py:103`
+
+---
+
+## LibreTranslate — No Normalisation
+
+LibreTranslate clients already use lowercase codes. The router passes them through to the plugin unchanged. The `source="auto"` sentinel is translated to `source=None` before calling the plugin:
+
+```python
+source = None if request.source == "auto" else request.source
+```
+
+Source: `ovos_translate_server/routers/libretranslate.py:67`
+
+---
+
+## Amazon — `auto` Sentinel
+
+Amazon Translate uses `SourceLanguageCode: "auto"` to request automatic source language detection. The router translates this to `source=None` before calling the plugin, then performs detection to fill in the actual source code returned in the response:
+
+```python
+source = None if request.SourceLanguageCode == "auto" else request.SourceLanguageCode
+```
+
+Source: `ovos_translate_server/routers/amazon_translate.py:55`
+
+---
+
+## Plugin Expectation
+
+The underlying OVOS `LanguageTranslator.translate()` method always receives lowercase BCP-47 codes for both `target` and `source`. Returning normalised output is the responsibility of each router.


### PR DESCRIPTION
Split from #14. Rebased on latest `dev` (cherry-picked docs commit only).

`docs/api-compatibility.md` (5 vendors, curl examples, prefix table) + `docs/language-codes.md` + `docs/detection.md` — cross-vendor, most useful together.

Docs-only PR — no code changes, no tests to run.