### PR TITLE
fix(compat): drive Amazon/Azure/LibreTranslate routers with their official SDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+TODO.md
+AGENTS.md

--- a/examples/amazon_example.py
+++ b/examples/amazon_example.py
@@ -1,0 +1,34 @@
+"""Drive the official boto3 Translate client against ovos-translate-server.
+
+Point ``endpoint_url`` at the ``/amazon`` router; boto3 posts its normal AWS
+JSON-RPC request (X-Amz-Target header + JSON body) which the router understands.
+No request rewriting needed.
+
+    pip install boto3
+    python examples/amazon_example.py "hello world" en de
+"""
+import sys
+
+import boto3
+from botocore.config import Config
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, source: str, target: str) -> None:
+    client = boto3.client(
+        "translate",
+        region_name="us-east-1",
+        aws_access_key_id="ignored",
+        aws_secret_access_key="ignored",
+        endpoint_url=f"{OVOS_HOST}/amazon",
+        config=Config(retries={"max_attempts": 0}),
+    )
+    resp = client.translate_text(Text=text, SourceLanguageCode=source, TargetLanguageCode=target)
+    print(resp["TranslatedText"])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <text> <source lang> <target lang>")
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/examples/azure_example.py
+++ b/examples/azure_example.py
@@ -1,0 +1,29 @@
+"""Drive the official azure-ai-translation-text (1.x) client against ovos-translate-server.
+
+Use the 1.x SDK (it speaks the Translator 3.0 wire format the ``/azure`` router
+implements; 2.x uses a different inputs/targets API and is NOT compatible).
+Point ``endpoint`` at the router; any key works since the server ignores auth.
+
+    pip install "azure-ai-translation-text<2"
+    python examples/azure_example.py "hello world" de
+"""
+import sys
+
+from azure.ai.translation.text import TextTranslationClient
+from azure.core.credentials import AzureKeyCredential
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, target: str) -> None:
+    client = TextTranslationClient(
+        endpoint=f"{OVOS_HOST}/azure", credential=AzureKeyCredential("ignored")
+    )
+    result = client.translate(body=[text], to_language=[target])
+    print(result[0].translations[0].text)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <text> <target lang>")
+    main(sys.argv[1], sys.argv[2])

--- a/examples/google_example.py
+++ b/examples/google_example.py
@@ -1,0 +1,29 @@
+"""Drive the official google-cloud-translate v2 client against ovos-translate-server.
+
+The Google v2 client posts to ``{api_endpoint}/language/translate/v2`` — point
+``api_endpoint`` at the ``/google`` router and use AnonymousCredentials to skip
+Google auth. No monkeypatching needed.
+
+    pip install google-cloud-translate
+    python examples/google_example.py "hello world" de
+"""
+import sys
+
+from google.auth.credentials import AnonymousCredentials
+from google.cloud import translate_v2
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, target: str) -> None:
+    client = translate_v2.Client(
+        credentials=AnonymousCredentials(),
+        client_options={"api_endpoint": f"{OVOS_HOST}/google"},
+    )
+    print(client.translate(text, target_language=target)["translatedText"])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <text> <target lang>")
+    main(sys.argv[1], sys.argv[2])

--- a/examples/libretranslate_example.py
+++ b/examples/libretranslate_example.py
@@ -1,0 +1,25 @@
+"""Drive the official libretranslatepy client against ovos-translate-server.
+
+Point the client URL at the ``/libretranslate`` router; it posts its normal
+form-encoded request which the router accepts (alongside JSON, like the
+reference LibreTranslate API). No request rewriting needed.
+
+    pip install libretranslatepy
+    python examples/libretranslate_example.py "hello world" en de
+"""
+import sys
+
+from libretranslatepy import LibreTranslateAPI
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, source: str, target: str) -> None:
+    client = LibreTranslateAPI(f"{OVOS_HOST}/libretranslate/")
+    print(client.translate(text, source, target))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <text> <source lang> <target lang>")
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/ovos_translate_server/routers/amazon_translate.py
+++ b/ovos_translate_server/routers/amazon_translate.py
@@ -1,8 +1,9 @@
 # Licensed under the Apache License, Version 2.0
 """Amazon Translate-compatible endpoint."""
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 
@@ -36,54 +37,25 @@ def make_amazon_translate_router(engine) -> APIRouter:
     """Create Amazon Translate-compatible router."""
     router = APIRouter(prefix="/amazon", tags=["amazon-translate"])
 
-    @router.post("/translate/text", response_model=AmazonTranslateResponse)
-    def translate_text(
-            request: AmazonTranslateRequest,
-            authorization: Optional[str] = Header(default=None),
-            x_amz_target: Optional[str] = Header(default=None, alias="X-Amz-Target"),
-    ) -> AmazonTranslateResponse:
-        """Translate text (Amazon Translate-compatible).
-
-        Args:
-            request: Amazon Translate request body.
-            authorization: AWS SigV4 auth header (accepted, ignored).
-            x_amz_target: AWS target header (accepted, ignored).
-
-        Returns:
-            AmazonTranslateResponse with translated text.
-        """
-        source = None if request.SourceLanguageCode == "auto" else request.SourceLanguageCode
-        translated = engine.tx.translate(request.Text, target=request.TargetLanguageCode, source=source)
-
-        # Detect source if auto
-        actual_source = request.SourceLanguageCode
+    def _translate(req: AmazonTranslateRequest) -> AmazonTranslateResponse:
+        source = None if req.SourceLanguageCode == "auto" else req.SourceLanguageCode
+        translated = engine.tx.translate(req.Text, target=req.TargetLanguageCode, source=source)
+        actual_source = req.SourceLanguageCode
         if source is None:
             try:
                 if engine.detect is not None:
-                    actual_source = engine.detect.detect(request.Text)
+                    actual_source = engine.detect.detect(req.Text)
                 else:
-                    actual_source = engine.tx.detect(request.Text)
+                    actual_source = engine.tx.detect(req.Text)
             except Exception:
                 actual_source = "und"
-
         return AmazonTranslateResponse(
             TranslatedText=translated or "",
             SourceLanguageCode=actual_source,
-            TargetLanguageCode=request.TargetLanguageCode,
+            TargetLanguageCode=req.TargetLanguageCode,
         )
 
-    @router.get("/translate/languages", response_model=AmazonListLanguagesResponse)
-    def list_languages(
-            authorization: Optional[str] = Header(default=None),
-    ) -> AmazonListLanguagesResponse:
-        """List supported languages (Amazon Translate-compatible).
-
-        Args:
-            authorization: AWS auth header (accepted, ignored).
-
-        Returns:
-            AmazonListLanguagesResponse with language list.
-        """
+    def _list_languages() -> AmazonListLanguagesResponse:
         languages = []
         for code in engine.langs:
             try:
@@ -93,5 +65,39 @@ def make_amazon_translate_router(engine) -> APIRouter:
                 name = code
             languages.append(AmazonLanguage(LanguageCode=code, LanguageName=name))
         return AmazonListLanguagesResponse(Languages=languages)
+
+    @router.post("", response_model=None)
+    async def aws_json_rpc(
+            request: Request,
+            x_amz_target: Optional[str] = Header(default=None, alias="X-Amz-Target"),
+    ) -> JSONResponse:
+        """AWS JSON-RPC entry point (what the boto3 ``translate`` client posts).
+
+        boto3 sends every action to the service root with an ``X-Amz-Target``
+        header (e.g. ``AWSShineFrontendService_20170701.TranslateText``) and a
+        JSON body, so dispatch on the action name here.
+        """
+        action = (x_amz_target or "").split(".")[-1]
+        body: Dict[str, Any] = await request.json() if await request.body() else {}
+        if action == "ListLanguages":
+            return JSONResponse(_list_languages().model_dump())
+        # default / TranslateText
+        return JSONResponse(_translate(AmazonTranslateRequest(**body)).model_dump())
+
+    @router.post("/translate/text", response_model=AmazonTranslateResponse)
+    def translate_text(
+            request: AmazonTranslateRequest,
+            authorization: Optional[str] = Header(default=None),
+            x_amz_target: Optional[str] = Header(default=None, alias="X-Amz-Target"),
+    ) -> AmazonTranslateResponse:
+        """Translate text (Amazon Translate-compatible REST convenience route)."""
+        return _translate(request)
+
+    @router.get("/translate/languages", response_model=AmazonListLanguagesResponse)
+    def list_languages(
+            authorization: Optional[str] = Header(default=None),
+    ) -> AmazonListLanguagesResponse:
+        """List supported languages (Amazon Translate-compatible REST route)."""
+        return _list_languages()
 
     return router

--- a/ovos_translate_server/routers/azure_translator.py
+++ b/ovos_translate_server/routers/azure_translator.py
@@ -3,12 +3,19 @@
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Header, Query
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class AzureTextItem(BaseModel):
-    """Single text item in Azure Translator request."""
-    Text: str = Field(..., min_length=1)
+    """Single text item in an Azure Translator request.
+
+    The official azure-ai-translation-text SDK serialises the item key as
+    lowercase ``text``; accept that (and the capitalised ``Text`` from the REST
+    docs) so the unmodified SDK works against this router.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+    Text: str = Field(..., min_length=1, validation_alias=AliasChoices("text", "Text"))
 
 
 class AzureTranslation(BaseModel):

--- a/ovos_translate_server/routers/libretranslate.py
+++ b/ovos_translate_server/routers/libretranslate.py
@@ -1,9 +1,38 @@
 # Licensed under the Apache License, Version 2.0
 """LibreTranslate-compatible translation endpoints."""
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
-from fastapi import APIRouter
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field, ValidationError
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+async def _read_payload(request: Request) -> Dict[str, Any]:
+    """Parse a LibreTranslate request body as JSON or form-encoded.
+
+    The reference LibreTranslate API accepts both, and the official
+    ``libretranslatepy`` client posts ``application/x-www-form-urlencoded``.
+    """
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        return await request.json()
+    if "form-urlencoded" in content_type or "multipart/form-data" in content_type:
+        return dict(await request.form())
+    try:
+        return await request.json()
+    except Exception:
+        return dict(await request.form())
+
+
+async def _parse(request: Request, model: Type[_M]) -> _M:
+    """Validate a JSON-or-form body, returning 422 on invalid input."""
+    try:
+        return model(**await _read_payload(request))
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=exc.errors()
+        ) from exc
 
 
 class LibreTranslateRequest(BaseModel):
@@ -55,29 +84,17 @@ def make_libretranslate_router(engine) -> APIRouter:
     router = APIRouter(prefix="/libretranslate", tags=["libretranslate"])
 
     @router.post("/translate", response_model=LibreTranslateResponse)
-    def translate(request: LibreTranslateRequest) -> LibreTranslateResponse:
-        """Translate text (LibreTranslate-compatible).
-
-        Args:
-            request: Translation request with text, source, and target language.
-
-        Returns:
-            LibreTranslateResponse with translated text.
-        """
+    async def translate(http_request: Request) -> LibreTranslateResponse:
+        """Translate text (LibreTranslate-compatible; JSON or form-encoded)."""
+        request = await _parse(http_request, LibreTranslateRequest)
         source = None if request.source == "auto" else request.source
         translated = engine.tx.translate(request.q, target=request.target, source=source)
         return LibreTranslateResponse(translatedText=translated or "")
 
     @router.post("/detect", response_model=List[LibreDetectEntry])
-    def detect(request: LibreDetectRequest) -> List[LibreDetectEntry]:
-        """Detect language of text (LibreTranslate-compatible).
-
-        Args:
-            request: Detection request with text.
-
-        Returns:
-            List of language detection results sorted by confidence descending.
-        """
+    async def detect(http_request: Request) -> List[LibreDetectEntry]:
+        """Detect language of text (LibreTranslate-compatible; JSON or form-encoded)."""
+        request = await _parse(http_request, LibreDetectRequest)
         if engine.detect is not None:
             probs = engine.detect.detect_probs(request.q)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 lang-names = ["langcodes"]
 mcp = ["mcp>=1.0.0"]
-test = ["pytest", "httpx", "uvicorn", "deepl"]
+test = ["pytest", "httpx", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-translate-server"

--- a/test/end2end/sdk_patches.py
+++ b/test/end2end/sdk_patches.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Point each vendor's *official* client SDK at the matching compat router.
+
+Each helper only sets the SDK's own endpoint/base-url knob to this server's
+``/<vendor>`` prefix — exactly what a DNS/pihole redirect to the server would
+achieve. No request rewriting: the SDK sends its normal request and the router
+is responsible for understanding it. If a client doesn't work here, the router
+is wrong, not the client.
+"""
+from __future__ import annotations
+
+
+def deepl_client(base_url: str):
+    """Official ``deepl`` SDK. ``server_url`` needs a trailing slash so the SDK's
+    ``urljoin(server_url, "v2/translate")`` keeps the ``/deepl`` prefix."""
+    import deepl
+
+    return deepl.Translator("ignored-key", server_url=f"{base_url}/deepl/")
+
+
+def google_client(base_url: str):
+    """Official ``google-cloud-translate`` v2 client (api_endpoint override)."""
+    from google.auth.credentials import AnonymousCredentials
+    from google.cloud import translate_v2
+
+    return translate_v2.Client(
+        credentials=AnonymousCredentials(),
+        client_options={"api_endpoint": f"{base_url}/google"},
+    )
+
+
+def azure_client(base_url: str):
+    """Official ``azure-ai-translation-text`` (1.x) client (endpoint override)."""
+    from azure.ai.translation.text import TextTranslationClient
+    from azure.core.credentials import AzureKeyCredential
+
+    return TextTranslationClient(
+        endpoint=f"{base_url}/azure", credential=AzureKeyCredential("ignored-key")
+    )
+
+
+def amazon_client(base_url: str):
+    """Official ``boto3`` ``translate`` client (endpoint_url override)."""
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "translate",
+        region_name="us-east-1",
+        aws_access_key_id="ignored",
+        aws_secret_access_key="ignored",
+        endpoint_url=f"{base_url}/amazon",
+        config=Config(retries={"max_attempts": 0}),
+    )
+
+
+def libretranslate_client(base_url: str):
+    """Official ``libretranslatepy`` client (base URL points at the router)."""
+    from libretranslatepy import LibreTranslateAPI
+
+    return LibreTranslateAPI(f"{base_url}/libretranslate/")

--- a/test/end2end/test_e2e_translate.py
+++ b/test/end2end/test_e2e_translate.py
@@ -100,8 +100,24 @@ def base_url():
     thread.join(timeout=5)
 
 
+# ---------------------------------------------------------------------------
+# Native endpoints
+# ---------------------------------------------------------------------------
+
+def test_native_status(base_url):
+    body = httpx.get(f"{base_url}/status", timeout=10).json()
+    assert body["plugin"] == "fake-translate"
+    assert "en" in body["langs"]
+
+
 def test_native_translate(base_url):
     resp = httpx.get(f"{base_url}/translate/de/hello", timeout=10)
+    assert resp.status_code == 200
+    assert "hello" in resp.text
+
+
+def test_native_translate_with_source(base_url):
+    resp = httpx.get(f"{base_url}/translate/en/de/hello", timeout=10)
     assert resp.status_code == 200
     assert "hello" in resp.text
 
@@ -112,15 +128,61 @@ def test_native_detect(base_url):
     assert "en" in resp.text
 
 
-def test_deepl_sdk(base_url):
-    """Official ``deepl`` SDK against the vendor-prefixed ``/deepl`` router.
+def test_native_classify(base_url):
+    resp = httpx.get(f"{base_url}/classify/hello", timeout=10)
+    assert resp.status_code == 200
+    assert "en" in resp.text
 
-    The SDK builds request URLs as ``urljoin(server_url, "v2/translate")``, so
-    ``server_url`` must keep a trailing slash for the ``/deepl`` prefix to
-    survive (``.../deepl/`` → ``.../deepl/v2/translate``; without it urljoin
-    drops the segment). See examples/deepl_example.py.
-    """
+
+# ---------------------------------------------------------------------------
+# Vendor-compatible routers — driven by each vendor's OFFICIAL client SDK.
+#
+# Where an SDK can't natively reach the /<vendor>-prefixed route, the minimal
+# documented monkeypatch lives in sdk_patches.py (and examples/<vendor>_*.py).
+# ---------------------------------------------------------------------------
+
+def test_deepl_sdk(base_url):
     deepl = pytest.importorskip("deepl", reason="deepl SDK not installed")
-    translator = deepl.Translator("fake-key", server_url=f"{base_url}/deepl/")
-    result = translator.translate_text("hello", target_lang="DE")
+    from . import sdk_patches
+
+    result = sdk_patches.deepl_client(base_url).translate_text("hello", target_lang="DE")
     assert "hello" in result.text
+
+
+def test_google_sdk(base_url):
+    pytest.importorskip("google.cloud.translate_v2", reason="google-cloud-translate not installed")
+    from . import sdk_patches
+
+    client = sdk_patches.google_client(base_url)
+    result = client.translate("hello", target_language="de")
+    assert "hello" in result["translatedText"]
+    assert client.detect_language("hello")["language"]
+
+
+def test_azure_sdk(base_url):
+    pytest.importorskip("azure.ai.translation.text", reason="azure SDK not installed")
+    from . import sdk_patches
+
+    result = sdk_patches.azure_client(base_url).translate(body=["hello"], to_language=["de"])
+    assert "hello" in result[0].translations[0].text
+
+
+def test_amazon_sdk(base_url):
+    pytest.importorskip("boto3", reason="boto3 not installed")
+    from . import sdk_patches
+
+    resp = sdk_patches.amazon_client(base_url).translate_text(
+        Text="hello", SourceLanguageCode="en", TargetLanguageCode="de"
+    )
+    assert "hello" in resp["TranslatedText"]
+    assert resp["TargetLanguageCode"] == "de"
+
+
+def test_libretranslate_sdk(base_url):
+    pytest.importorskip("libretranslatepy", reason="libretranslatepy not installed")
+    from . import sdk_patches
+
+    client = sdk_patches.libretranslate_client(base_url)
+    assert "hello" in client.translate("hello", "en", "de")
+    assert client.detect("hello")
+    assert client.languages()

--- a/test/unittests/test_libretranslate_compat.py
+++ b/test/unittests/test_libretranslate_compat.py
@@ -133,14 +133,16 @@ class TestLibreTranslateRouter:
         )
         assert resp.status_code == 422
 
-    def test_translate_wrong_content_type(self, client):
-        """Sending form data instead of JSON must return 422."""
+    def test_translate_form_encoded_accepted(self, client):
+        """Form-encoded bodies are accepted, like the reference LibreTranslate API
+        (and the official libretranslatepy client, which posts form data)."""
         resp = client.post(
             "/libretranslate/translate",
             data="q=hello&source=en&target=de",
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
-        assert resp.status_code == 422
+        assert resp.status_code == 200
+        assert "translatedText" in resp.json()
 
     def test_detect_no_detect_plugin_falls_back_to_tx(self):
         """When engine.detect is None, detect endpoint must use engine.tx.detect_probs."""


### PR DESCRIPTION
Recovers work orphaned when #34 squash-merged only its first commits.

Every translate compat router is now driven by its **official vendor SDK** pointed at the `/<vendor>` route via the SDK's own endpoint knob (DNS-redirect style) — no client request rewriting. Where the SDK's normal request failed, the **router was fixed** (it was hallucinated):
- **amazon**: boto3 posts AWS JSON-RPC to the service root with `X-Amz-Target` → added a root dispatcher (REST routes kept).
- **azure**: `azure-ai-translation-text` sends lowercase `text` → accept it (+ documented `Text`).
- **libretranslate**: official client posts form-encoded → accept form + JSON (422 on invalid).

Adds e2e covering every endpoint via its official SDK, `examples/<vendor>_example.py`, and the SDKs in the test extra. 141 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example scripts demonstrating translation with Amazon Translate, Azure, Google Cloud Translate, and LibreTranslate SDKs
  * AWS JSON-RPC support for translate service

* **Bug Fixes**
  * Azure Translator v3 compatibility for request parsing
  * LibreTranslate form-encoded request support

* **Tests**
  * Expanded end-to-end tests covering vendor SDKs (Google, Azure, Amazon, LibreTranslate)
  * Added SDK compatibility testing helpers

* **Chores**
  * Updated .gitignore configuration
  * Added test dependencies for translation vendors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->