### PR TITLE
feat(compat): add DeepLX and Lingva translation-compatible endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,54 @@ app, engine = start_translate_server("ovos-translate-plugin-nllb")
 }
 ```
 
+## Vendor-compatible endpoints
+
+The server mounts compat routers so existing tools, SDKs, and scripts that
+already target a commercial translation API can be pointed at your local OVOS
+instance with zero code changes.
+
+| Vendor | Prefix | Key endpoints |
+|--------|--------|---------------|
+| DeepL (official SDK) | `/deepl` | `POST /deepl/v2/translate` |
+| DeepLX | `/deeplx` | `POST /deeplx/translate` |
+| LibreTranslate | `/libretranslate` | `POST /libretranslate/translate`, `POST /libretranslate/detect`, `GET /libretranslate/languages` |
+| Lingva Translate | `/lingva` | `GET /lingva/api/v1/{source}/{target}/{query}` |
+| Google Cloud Translation | `/google` | `POST /google/language/translate/v2` |
+| Azure Translator | `/azure` | `POST /azure/translate` |
+| Amazon Translate | `/amazon` | `POST /amazon/translate/text` |
+
+### DeepLX
+
+DeepLX is an open-source free DeepL-compatible proxy.  Its schema is simpler
+than the official DeepL v2 API: a single endpoint with `{text, source_lang,
+target_lang}` returning `{code, data}`.
+
+```bash
+curl -s http://localhost:9686/deeplx/translate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello", "source_lang": "EN", "target_lang": "DE"}'
+# {"code":200,"data":"..."}
+```
+
+See `examples/deeplx_example.py` for a runnable script.
+
+### Lingva Translate
+
+Lingva Translate uses a REST GET endpoint with path parameters.  Use `auto`
+as the source language for automatic detection.
+
+```bash
+curl -s "http://localhost:9686/lingva/api/v1/en/de/hello%20world"
+# {"translation":"..."}
+```
+
+```bash
+# Auto-detect source language
+curl -s "http://localhost:9686/lingva/api/v1/auto/fr/bonjour"
+```
+
+See `examples/lingva_example.py` for a runnable script.
+
 ## Docker
 
 you can create easily crete a docker file to serve any plugin

--- a/examples/deeplx_example.py
+++ b/examples/deeplx_example.py
@@ -7,6 +7,10 @@ This compat router is distinct from the official DeepL v2 router (``/deepl``):
 it uses the simpler DeepLX schema, making it a drop-in replacement for
 any tool or script already targeting a DeepLX server.
 
+DeepLX is an open-source proxy with **no official Python SDK** (it is consumed
+by CLI tools and browser extensions over plain HTTP), so this example calls the
+HTTP endpoint directly rather than driving a vendor SDK.
+
 Prerequisites:
     ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
 

--- a/examples/deeplx_example.py
+++ b/examples/deeplx_example.py
@@ -1,0 +1,56 @@
+"""Drive a DeepLX-compatible client against an ovos-translate-server instance.
+
+DeepLX exposes a single ``POST /translate`` endpoint that accepts
+``{text, source_lang, target_lang}`` and returns ``{code, data}``.
+
+This compat router is distinct from the official DeepL v2 router (``/deepl``):
+it uses the simpler DeepLX schema, making it a drop-in replacement for
+any tool or script already targeting a DeepLX server.
+
+Prerequisites:
+    ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
+
+Usage:
+    python examples/deeplx_example.py "hello world" DE
+    python examples/deeplx_example.py "bonjour" EN auto
+"""
+import sys
+
+try:
+    import httpx as _http
+
+    def post(url, payload):
+        return _http.post(url, json=payload, timeout=30)
+except ImportError:
+    import urllib.request, json as _json
+
+    class _FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def post(url, payload):
+        body = _json.dumps(payload).encode()
+        req = urllib.request.Request(url, data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return _FakeResp(_json.loads(r.read()))
+
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, target_lang: str, source_lang: str = "auto") -> None:
+    url = f"{OVOS_HOST}/deeplx/translate"
+    payload = {"text": text, "source_lang": source_lang, "target_lang": target_lang}
+    resp = post(url, payload)
+    body = resp.json()
+    print(f"code={body['code']}  data={body['data']!r}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (3, 4):
+        sys.exit(f"usage: {sys.argv[0]} <text> <TARGET_LANG e.g. DE> [SOURCE_LANG e.g. EN or auto]")
+    main(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) == 4 else "auto")

--- a/examples/lingva_example.py
+++ b/examples/lingva_example.py
@@ -1,0 +1,52 @@
+"""Drive a Lingva Translate-compatible client against an ovos-translate-server instance.
+
+Lingva Translate uses ``GET /api/v1/{source}/{target}/{query}`` returning
+``{translation}``.  Use ``auto`` as the source language for automatic detection.
+
+Prerequisites:
+    ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
+
+Usage:
+    python examples/lingva_example.py "hello world" de en
+    python examples/lingva_example.py "bonjour le monde" en auto
+"""
+import sys
+import urllib.parse
+
+try:
+    import httpx as _http
+
+    def get(url):
+        return _http.get(url, timeout=30)
+except ImportError:
+    import urllib.request, json as _json
+
+    class _FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def get(url):
+        with urllib.request.urlopen(url, timeout=30) as r:
+            return _FakeResp(_json.loads(r.read()))
+
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(query: str, target_lang: str, source_lang: str = "auto") -> None:
+    encoded = urllib.parse.quote(query, safe="")
+    url = f"{OVOS_HOST}/lingva/api/v1/{source_lang}/{target_lang}/{encoded}"
+    resp = get(url)
+    body = resp.json()
+    print(f"translation={body['translation']!r}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (3, 4):
+        sys.exit(
+            f"usage: {sys.argv[0]} <text> <target_lang e.g. de> [source_lang e.g. en or auto]"
+        )
+    main(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) == 4 else "auto")

--- a/examples/lingva_example.py
+++ b/examples/lingva_example.py
@@ -3,6 +3,10 @@
 Lingva Translate uses ``GET /api/v1/{source}/{target}/{query}`` returning
 ``{translation}``.  Use ``auto`` as the source language for automatic detection.
 
+Lingva is an open-source Google Translate front end with **no official Python
+SDK** (it is consumed by web/CLI clients over plain HTTP), so this example calls
+the HTTP endpoint directly rather than driving a vendor SDK.
+
 Prerequisites:
     ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
 

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -139,10 +139,14 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
     from ovos_translate_server.routers.google_translate import make_google_translate_router
     from ovos_translate_server.routers.amazon_translate import make_amazon_translate_router
     from ovos_translate_server.routers.deepl import make_deepl_router
+    from ovos_translate_server.routers.deeplx import make_deeplx_router
     from ovos_translate_server.routers.libretranslate import make_libretranslate_router
-    
+    from ovos_translate_server.routers.lingva import make_lingva_router
+
     app.include_router(make_deepl_router(engine))
+    app.include_router(make_deeplx_router(engine))
     app.include_router(make_libretranslate_router(engine))
+    app.include_router(make_lingva_router(engine))
     app.include_router(make_amazon_translate_router(engine))
     app.include_router(make_google_translate_router(engine))
     app.include_router(make_azure_translator_router(engine))

--- a/ovos_translate_server/routers/deeplx.py
+++ b/ovos_translate_server/routers/deeplx.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0
+"""DeepLX-compatible translation endpoints.
+
+DeepLX is an open-source free DeepL-compatible proxy. Its API surface is
+distinct from the official DeepL v2 API (handled by ``deepl.py``): a single
+``POST /translate`` endpoint with a simpler JSON schema.
+"""
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+
+class DeepLXTranslateRequest(BaseModel):
+    """Request body for POST /translate (DeepLX schema)."""
+
+    text: str = Field(..., min_length=1)
+    source_lang: str = Field(default="auto")
+    target_lang: str = Field(..., min_length=1)
+
+
+class DeepLXTranslateResponse(BaseModel):
+    """Response for POST /translate (DeepLX schema)."""
+
+    code: int = 200
+    data: str
+
+
+def make_deeplx_router(engine) -> APIRouter:
+    """Create DeepLX-compatible router.
+
+    The DeepLX API exposes a single ``POST /translate`` endpoint that accepts
+    ``{text, source_lang, target_lang}`` and returns ``{code, data}``.
+
+    Args:
+        engine: TranslateEngineWrapper instance.
+
+    Returns:
+        Configured APIRouter with DeepLX-compatible /translate endpoint.
+    """
+    router = APIRouter(prefix="/deeplx", tags=["deeplx"])
+
+    @router.post("/translate", response_model=DeepLXTranslateResponse)
+    def translate(request: DeepLXTranslateRequest) -> DeepLXTranslateResponse:
+        """Translate text (DeepLX-compatible).
+
+        Args:
+            request: DeepLX translation request with text and language codes.
+
+        Returns:
+            DeepLXTranslateResponse with status code and translated text.
+        """
+        source: Optional[str] = None if request.source_lang.lower() == "auto" else request.source_lang.lower()
+        target = request.target_lang.lower()
+        translated = engine.tx.translate(request.text, target=target, source=source)
+        return DeepLXTranslateResponse(code=200, data=translated or "")
+
+    return router

--- a/ovos_translate_server/routers/lingva.py
+++ b/ovos_translate_server/routers/lingva.py
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0
+"""Lingva Translate-compatible translation endpoints.
+
+Lingva Translate exposes a REST API at ``GET /api/v1/{source}/{target}/{query}``
+returning ``{translation}``.  Source ``auto`` means auto-detect.
+"""
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+
+class LingvaTranslateResponse(BaseModel):
+    """Response for GET /api/v1/{source}/{target}/{query}."""
+
+    translation: str
+
+
+def make_lingva_router(engine) -> APIRouter:
+    """Create Lingva Translate-compatible router.
+
+    The Lingva API uses a GET endpoint with path parameters for source language,
+    target language, and the query text, returning ``{translation}``.
+
+    Args:
+        engine: TranslateEngineWrapper instance.
+
+    Returns:
+        Configured APIRouter with Lingva-compatible /api/v1 endpoint.
+    """
+    router = APIRouter(prefix="/lingva", tags=["lingva"])
+
+    @router.get("/api/v1/{source}/{target}/{query}", response_model=LingvaTranslateResponse)
+    def translate(source: str, target: str, query: str) -> LingvaTranslateResponse:
+        """Translate query text (Lingva Translate-compatible).
+
+        Args:
+            source: Source language code, or ``auto`` for auto-detection.
+            target: Target language code.
+            query: Text to translate.
+
+        Returns:
+            LingvaTranslateResponse with translated text.
+        """
+        src = None if source.lower() == "auto" else source.lower()
+        translated = engine.tx.translate(query, target=target.lower(), source=src)
+        return LingvaTranslateResponse(translation=translated or "")
+
+    return router

--- a/test/unittests/test_deeplx_compat.py
+++ b/test/unittests/test_deeplx_compat.py
@@ -1,0 +1,174 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the DeepLX compatibility router."""
+from typing import Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fake engine
+# ---------------------------------------------------------------------------
+
+class FakeTx:
+    available_languages: List[str] = ["en", "de", "fr", "es"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.95, "de": 0.03, "fr": 0.02}
+
+
+class FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr", "es"]
+
+    def __init__(self) -> None:
+        self.tx = FakeTx()
+        self.detect = None
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return FakeEngine()
+
+
+@pytest.fixture(scope="module")
+def client(engine):
+    from ovos_translate_server.routers.deeplx import make_deeplx_router
+    app = FastAPI()
+    app.include_router(make_deeplx_router(engine))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# DeepLX  (prefix: /deeplx)
+# ---------------------------------------------------------------------------
+
+class TestDeepLXRouter:
+    def test_translate_basic(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "source_lang": "EN", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+        assert "[de]" in body["data"]
+
+    def test_translate_auto_source(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "source_lang": "auto", "target_lang": "FR"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+        assert "data" in body
+
+    def test_translate_default_source_is_auto(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+
+    def test_missing_target_lang_rejected(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello"},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_text_rejected(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "", "target_lang": "DE"},
+        )
+        assert resp.status_code == 422
+
+    def test_response_envelope_keys(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "code" in body
+        assert "data" in body
+
+    def test_data_is_string(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "FR"},
+        )
+        assert resp.status_code == 200
+        assert isinstance(resp.json()["data"], str)
+
+    def test_delegates_to_engine_translate(self, engine):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.deeplx import make_deeplx_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append({"text": text, "target": target, "source": source})
+                return f"[{target}] {text}"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_deeplx_router(eng))
+        c = TestClient(app)
+        c.post("/deeplx/translate", json={"text": "world", "source_lang": "EN", "target_lang": "DE"})
+        assert len(calls) == 1
+        assert calls[0]["text"] == "world"
+        assert calls[0]["target"] == "de"
+        assert calls[0]["source"] == "en"
+
+    def test_auto_source_passes_none_to_engine(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.deeplx import make_deeplx_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append(source)
+                return "translated"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_deeplx_router(eng))
+        c = TestClient(app)
+        c.post("/deeplx/translate", json={"text": "hello", "source_lang": "auto", "target_lang": "DE"})
+        assert calls[0] is None

--- a/test/unittests/test_lingva_compat.py
+++ b/test/unittests/test_lingva_compat.py
@@ -1,0 +1,142 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the Lingva Translate compatibility router."""
+from typing import Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fake engine
+# ---------------------------------------------------------------------------
+
+class FakeTx:
+    available_languages: List[str] = ["en", "de", "fr", "es"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.95, "de": 0.03, "fr": 0.02}
+
+
+class FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr", "es"]
+
+    def __init__(self) -> None:
+        self.tx = FakeTx()
+        self.detect = None
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return FakeEngine()
+
+
+@pytest.fixture(scope="module")
+def client(engine):
+    from ovos_translate_server.routers.lingva import make_lingva_router
+    app = FastAPI()
+    app.include_router(make_lingva_router(engine))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Lingva  (prefix: /lingva)
+# ---------------------------------------------------------------------------
+
+class TestLingvaRouter:
+    def test_translate_basic(self, client):
+        resp = client.get("/lingva/api/v1/en/de/hello")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "translation" in body
+        assert "[de]" in body["translation"]
+
+    def test_translate_auto_source(self, client):
+        resp = client.get("/lingva/api/v1/auto/fr/hello")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "translation" in body
+
+    def test_translation_is_string(self, client):
+        resp = client.get("/lingva/api/v1/en/es/world")
+        assert resp.status_code == 200
+        assert isinstance(resp.json()["translation"], str)
+
+    def test_response_envelope_key(self, client):
+        resp = client.get("/lingva/api/v1/en/de/test")
+        assert resp.status_code == 200
+        assert set(resp.json().keys()) == {"translation"}
+
+    def test_delegates_to_engine_translate(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.lingva import make_lingva_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append({"text": text, "target": target, "source": source})
+                return f"[{target}] {text}"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_lingva_router(eng))
+        c = TestClient(app)
+        c.get("/lingva/api/v1/en/de/hello world")
+        assert len(calls) == 1
+        assert calls[0]["text"] == "hello world"
+        assert calls[0]["target"] == "de"
+        assert calls[0]["source"] == "en"
+
+    def test_auto_source_passes_none_to_engine(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.lingva import make_lingva_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append(source)
+                return "translated"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_lingva_router(eng))
+        c = TestClient(app)
+        c.get("/lingva/api/v1/auto/de/bonjour")
+        assert calls[0] is None
+
+    def test_different_target_langs(self, client):
+        for lang in ["de", "fr", "es"]:
+            resp = client.get(f"/lingva/api/v1/en/{lang}/hello")
+            assert resp.status_code == 200
+            assert f"[{lang}]" in resp.json()["translation"]


### PR DESCRIPTION
## Summary

- Adds deeplx.py router (prefix /deeplx): POST /translate mirroring DeepLX schema ({text, source_lang, target_lang} → {code, data}).
- Adds lingva.py router (prefix /lingva): GET /api/v1/{source}/{target}/{query} mirroring Lingva Translate API returning {translation}.
- Both routers registered in create_app().
- examples/deeplx_example.py and examples/lingva_example.py added.
- 16 new unit tests (9 DeepLX + 7 Lingva) using FastAPI TestClient + fake engine (no network).

## Test plan

- [ ] pytest test/unittests/test_deeplx_compat.py test/unittests/test_lingva_compat.py -- 16/16 pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)