### PR TITLE
feat(compat): add DeepLX-compatible translation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,39 @@ app, engine = start_translate_server("ovos-translate-plugin-nllb")
 }
 ```
 
+## Vendor-compatible endpoints
+
+The server mounts compat routers so existing tools, SDKs, and scripts that
+already target a commercial translation API can be pointed at your local OVOS
+instance with zero code changes. See [docs/api-compatibility.md](docs/api-compatibility.md)
+for the full reference.
+
+| Vendor | Prefix | Key endpoints |
+|--------|--------|---------------|
+| DeepL (official SDK) | `/deepl` | `POST /deepl/v2/translate` |
+| DeepLX | `/deeplx` | `POST /deeplx/translate` |
+| LibreTranslate | `/libretranslate` | `POST /libretranslate/translate`, `POST /libretranslate/detect`, `GET /libretranslate/languages` |
+| Google Cloud Translation | `/google` | `POST /google/language/translate/v2` |
+| Azure Translator | `/azure` | `POST /azure/translate` |
+| Amazon Translate | `/amazon` | `POST /amazon/translate/text` |
+
+### DeepLX
+
+DeepLX is an open-source free DeepL-compatible proxy.  Its schema is simpler
+than the official DeepL v2 API: a single endpoint with `{text, source_lang,
+target_lang}` returning `{code, data}`.
+
+```bash
+curl -s http://localhost:9686/deeplx/translate \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello", "source_lang": "EN", "target_lang": "DE"}'
+# {"code":200,"data":"..."}
+```
+
+DeepLX has no official Python SDK; the maintained community client `deeplx-tr`
+can be pointed at this server via its `url` argument.  See
+`examples/deeplx_example.py` for a runnable script.
+
 ## Docker
 
 you can create easily crete a docker file to serve any plugin

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,6 +1,6 @@
 # API Compatibility — `ovos-translate-server`
 
-`ovos-translate-server` exposes five vendor-compatible routers so that existing clients written for LibreTranslate, DeepL, Google Cloud Translation, Azure Translator, or Amazon Translate can point at this server with minimal or no code changes.
+`ovos-translate-server` exposes several vendor-compatible routers so that existing clients written for LibreTranslate, DeepL, DeepLX, Google Cloud Translation, Azure Translator, or Amazon Translate can point at this server with minimal or no code changes.
 
 ---
 
@@ -14,6 +14,7 @@ Every router is therefore mounted under a unique vendor prefix:
 |--------|--------|
 | LibreTranslate | `/libretranslate` |
 | DeepL | `/deepl` |
+| DeepLX | `/deeplx` |
 | Google Cloud Translation v2 | `/google` |
 | Azure Translator v3 | `/azure` |
 | Amazon Translate | `/amazon` |
@@ -30,6 +31,7 @@ Without these prefixes, `/translate` would be registered five times and only the
 | LibreTranslate | POST | `/libretranslate/detect` | `api_key` body field (ignored) | lowercase BCP-47 | Returns list sorted by confidence desc |
 | LibreTranslate | GET | `/libretranslate/languages` | — | lowercase BCP-47 | Returns `{code, name}` list |
 | DeepL | POST | `/deepl/v2/translate` | `Authorization: DeepL-Auth-Key …` (ignored) | uppercase BCP-47 e.g. `EN-US` | Accepts/returns uppercase; normalised internally |
+| DeepLX | POST | `/deeplx/translate` | — | case-insensitive BCP-47 | `{text, source_lang, target_lang}` → `{code, data}`; `source_lang: "auto"` triggers auto-detect |
 | Google | POST | `/google/language/translate/v2` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | `q` may be string or list |
 | Google | POST | `/google/language/translate/v2/detect` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | `q` may be string or list |
 | Google | GET | `/google/language/translate/v2/languages` | `key` query param or `Authorization` header (ignored) | lowercase BCP-47 | Optional `target` query param accepted |
@@ -76,6 +78,24 @@ curl -s -X POST http://localhost:9686/deepl/v2/translate \
   -H 'Authorization: DeepL-Auth-Key dummy-key' \
   -d '{"text": ["Hello world"], "target_lang": "DE"}'
 # {"translations": [{"detected_source_language": "EN", "text": "Hallo Welt"}]}
+```
+
+### DeepLX — Translate
+
+DeepLX uses a simpler single-endpoint schema than the official DeepL v2 API.
+
+```bash
+curl -s -X POST http://localhost:9686/deeplx/translate \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Hello world", "source_lang": "EN", "target_lang": "DE"}'
+# {"code": 200, "data": "Hallo Welt"}
+```
+
+```bash
+# Auto-detect the source language
+curl -s -X POST http://localhost:9686/deeplx/translate \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Bonjour le monde", "source_lang": "auto", "target_lang": "EN"}'
 ```
 
 ### Google Cloud Translation — Translate
@@ -188,6 +208,24 @@ The official `deepl` library uses `https://api.deepl.com` as the server URL. Pas
 import deepl
 translator = deepl.Translator("dummy-key", server_url="http://localhost:9686/deepl")
 result = translator.translate_text("Hello world", target_lang="DE")
+```
+
+### DeepLX client
+
+DeepLX ships **no official Python SDK** — it is normally consumed by CLI tools
+and browser extensions over plain HTTP (see the curl example above). The
+maintained community client `deeplx-tr` exposes a `url` knob that can point at
+this server's `/deeplx/translate` endpoint:
+
+```python
+from deeplx_tr import deeplx_client
+
+result = deeplx_client(
+    "Hello world",
+    source_lang="en",
+    target_lang="de",
+    url="http://localhost:9686/deeplx/translate",
+)
 ```
 
 ### Google Cloud Translation client

--- a/docs/language-codes.md
+++ b/docs/language-codes.md
@@ -10,6 +10,7 @@ Each vendor API has its own convention for language code format. `ovos-translate
 |--------|---------------|----------------|-----------------|-----------------|
 | LibreTranslate | lowercase BCP-47 | `en`, `de` | lowercase BCP-47 | `en`, `de` |
 | DeepL | uppercase BCP-47 | `EN`, `EN-US`, `DE` | uppercase BCP-47 | `EN`, `EN-US` |
+| DeepLX | case-insensitive BCP-47 | `EN`, `de`, `auto` | no code echoed | — |
 | Google | lowercase BCP-47 | `en`, `de`, `en-us` | lowercase BCP-47 | `en`, `de` |
 | Azure | mixed BCP-47 | `en`, `de`, `en-US` | target code echoed unchanged | `de` |
 | Amazon | lowercase BCP-47 | `en`, `de`, `auto` | lowercase BCP-47 | `en`, `de` |
@@ -33,6 +34,27 @@ detected_source = engine.detect.detect(item).upper()
 - `detected_source_language` in the response is always uppercased (e.g. `EN`)
 
 Source: `ovos_translate_server/routers/deepl.py:57–71`
+
+---
+
+## DeepLX Normalisation — `routers/deeplx.py`
+
+DeepLX clients conventionally send uppercase codes (`EN`, `DE`) but the format is
+not enforced. The router lowercases both codes before calling the plugin and
+treats the `source_lang: "auto"` sentinel as automatic detection. The DeepLX
+response schema (`{code, data}`) carries no language code, so there is nothing to
+echo back.
+
+```python
+# deeplx.py — translate handler
+source = None if request.source_lang.lower() == "auto" else request.source_lang.lower()
+target = request.target_lang.lower()
+```
+
+- `source_lang` (e.g. `EN`, or `auto`) → lowercased to `en`, or `None` for auto-detect
+- `target_lang` (e.g. `DE`) → lowercased to `de`
+
+Source: `ovos_translate_server/routers/deeplx.py`
 
 ---
 

--- a/examples/deeplx_example.py
+++ b/examples/deeplx_example.py
@@ -1,0 +1,65 @@
+"""Drive a DeepLX-compatible client against an ovos-translate-server instance.
+
+DeepLX exposes a single ``POST /translate`` endpoint that accepts
+``{text, source_lang, target_lang}`` and returns ``{code, data}``.
+
+This compat router is distinct from the official DeepL v2 router (``/deepl``):
+it uses the simpler DeepLX schema, making it a drop-in replacement for
+any tool or script already targeting a DeepLX server.
+
+DeepLX is an open-source proxy with **no official Python SDK** (it is consumed
+by CLI tools and browser extensions over plain HTTP), so this example calls the
+HTTP endpoint directly. To drive it with the maintained community client
+instead, install ``deeplx-tr`` and point its ``url`` at this server::
+
+    from deeplx_tr import deeplx_client
+    deeplx_client("hello", target_lang="de",
+                  url="http://localhost:9686/deeplx/translate")
+
+Prerequisites:
+    ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
+
+Usage:
+    python examples/deeplx_example.py "hello world" DE
+    python examples/deeplx_example.py "bonjour" EN auto
+"""
+import sys
+
+try:
+    import httpx as _http
+
+    def post(url, payload):
+        return _http.post(url, json=payload, timeout=30)
+except ImportError:
+    import urllib.request, json as _json
+
+    class _FakeResp:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+    def post(url, payload):
+        body = _json.dumps(payload).encode()
+        req = urllib.request.Request(url, data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return _FakeResp(_json.loads(r.read()))
+
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def main(text: str, target_lang: str, source_lang: str = "auto") -> None:
+    url = f"{OVOS_HOST}/deeplx/translate"
+    payload = {"text": text, "source_lang": source_lang, "target_lang": target_lang}
+    resp = post(url, payload)
+    body = resp.json()
+    print(f"code={body['code']}  data={body['data']!r}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (3, 4):
+        sys.exit(f"usage: {sys.argv[0]} <text> <TARGET_LANG e.g. DE> [SOURCE_LANG e.g. EN or auto]")
+    main(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) == 4 else "auto")

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -139,9 +139,11 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
     from ovos_translate_server.routers.google_translate import make_google_translate_router
     from ovos_translate_server.routers.amazon_translate import make_amazon_translate_router
     from ovos_translate_server.routers.deepl import make_deepl_router
+    from ovos_translate_server.routers.deeplx import make_deeplx_router
     from ovos_translate_server.routers.libretranslate import make_libretranslate_router
-    
+
     app.include_router(make_deepl_router(engine))
+    app.include_router(make_deeplx_router(engine))
     app.include_router(make_libretranslate_router(engine))
     app.include_router(make_amazon_translate_router(engine))
     app.include_router(make_google_translate_router(engine))

--- a/ovos_translate_server/routers/deeplx.py
+++ b/ovos_translate_server/routers/deeplx.py
@@ -1,0 +1,58 @@
+# Licensed under the Apache License, Version 2.0
+"""DeepLX-compatible translation endpoints.
+
+DeepLX is an open-source free DeepL-compatible proxy. Its API surface is
+distinct from the official DeepL v2 API (handled by ``deepl.py``): a single
+``POST /translate`` endpoint with a simpler JSON schema.
+"""
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+
+class DeepLXTranslateRequest(BaseModel):
+    """Request body for POST /translate (DeepLX schema)."""
+
+    text: str = Field(..., min_length=1)
+    source_lang: str = Field(default="auto")
+    target_lang: str = Field(..., min_length=1)
+
+
+class DeepLXTranslateResponse(BaseModel):
+    """Response for POST /translate (DeepLX schema)."""
+
+    code: int = 200
+    data: str
+
+
+def make_deeplx_router(engine) -> APIRouter:
+    """Create DeepLX-compatible router.
+
+    The DeepLX API exposes a single ``POST /translate`` endpoint that accepts
+    ``{text, source_lang, target_lang}`` and returns ``{code, data}``.
+
+    Args:
+        engine: TranslateEngineWrapper instance.
+
+    Returns:
+        Configured APIRouter with DeepLX-compatible /translate endpoint.
+    """
+    router = APIRouter(prefix="/deeplx", tags=["deeplx"])
+
+    @router.post("/translate", response_model=DeepLXTranslateResponse)
+    def translate(request: DeepLXTranslateRequest) -> DeepLXTranslateResponse:
+        """Translate text (DeepLX-compatible).
+
+        Args:
+            request: DeepLX translation request with text and language codes.
+
+        Returns:
+            DeepLXTranslateResponse with status code and translated text.
+        """
+        source: Optional[str] = None if request.source_lang.lower() == "auto" else request.source_lang.lower()
+        target = request.target_lang.lower()
+        translated = engine.tx.translate(request.text, target=target, source=source)
+        return DeepLXTranslateResponse(code=200, data=translated or "")
+
+    return router

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ dependencies = [
 [project.optional-dependencies]
 lang-names = ["langcodes"]
 mcp = ["mcp>=1.0.0"]
-test = ["pytest", "httpx", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy"]
+# deeplx-tr is the maintained community client for DeepLX (no official SDK exists);
+# it pulls `environs`, which breaks on marshmallow>=4, hence the pin so the DeepLX
+# e2e test imports and actually runs instead of being silently skipped.
+test = ["pytest", "httpx", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy", "deeplx-tr", "marshmallow<4"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-translate-server"

--- a/test/end2end/sdk_patches.py
+++ b/test/end2end/sdk_patches.py
@@ -69,3 +69,20 @@ def libretranslate_client(base_url: str):
     from libretranslatepy import LibreTranslateAPI
 
     return LibreTranslateAPI(f"{base_url}/libretranslate/")
+
+
+def deeplx_client(base_url: str):
+    """Community ``deeplx-tr`` client bound to this server's ``/deeplx`` router.
+
+    DeepLX ships no official Python SDK; ``deeplx-tr`` is the maintained
+    community client. Its ``deeplx_client(text, ..., url=...)`` helper posts the
+    DeepLX ``{text, source_lang, target_lang}`` schema and reads ``data`` from
+    the response — exactly what :func:`make_deeplx_router` serves. We bind the
+    ``url`` to the router's ``/deeplx/translate`` endpoint and return a callable
+    with the same ``(text, source_lang, target_lang)`` signature.
+    """
+    from functools import partial
+
+    from deeplx_tr import deeplx_client as _deeplx_client
+
+    return partial(_deeplx_client, url=f"{base_url}/deeplx/translate")

--- a/test/end2end/test_e2e_deeplx.py
+++ b/test/end2end/test_e2e_deeplx.py
@@ -1,0 +1,137 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests for the DeepLX-compatible router.
+
+Boots the full app (``create_app``) with a fake engine on a uvicorn server and
+drives the ``/deeplx`` router two ways:
+
+* the documented HTTP contract directly (``POST /deeplx/translate``), and
+* the maintained community client ``deeplx-tr`` — DeepLX ships no official
+  Python SDK, so ``deeplx-tr`` is the closest equivalent. Its ``url`` knob is
+  pointed at this server's ``/deeplx/translate`` endpoint, exactly what a
+  DNS/pihole redirect to the server would achieve. No request rewriting: the
+  client sends its normal DeepLX request and the router understands it.
+
+Run in isolation::
+
+    pytest test/end2end/test_e2e_deeplx.py -v
+"""
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from typing import Dict, List, Optional
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI
+
+
+class _FakeTx:
+    available_languages: List[str] = ["en", "de", "fr", "es"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.95, "de": 0.05}
+
+
+class _FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr", "es"]
+
+    def __init__(self) -> None:
+        self.tx = _FakeTx()
+        self.detect = None
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _build_app() -> FastAPI:
+    from ovos_translate_server import create_app
+    return create_app(_FakeEngine())
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    port = _free_port()
+    config = uvicorn.Config(_build_app(), host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.time() + 10
+    url = f"http://127.0.0.1:{port}"
+    while time.time() < deadline:
+        try:
+            if httpx.get(f"{url}/status", timeout=1).status_code == 200:
+                break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        server.should_exit = True
+        raise RuntimeError("server did not start in time")
+
+    yield url
+
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# HTTP contract — what any DeepLX client (CLI tools, browser extensions) sends.
+# ---------------------------------------------------------------------------
+
+def test_deeplx_http_translate(base_url):
+    resp = httpx.post(
+        f"{base_url}/deeplx/translate",
+        json={"text": "hello", "source_lang": "EN", "target_lang": "DE"},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code"] == 200
+    assert "hello" in body["data"]
+
+
+def test_deeplx_http_autodetect(base_url):
+    resp = httpx.post(
+        f"{base_url}/deeplx/translate",
+        json={"text": "bonjour", "source_lang": "auto", "target_lang": "EN"},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    assert "bonjour" in resp.json()["data"]
+
+
+# ---------------------------------------------------------------------------
+# Community client — DeepLX has no official SDK; deeplx-tr is the maintained
+# community client. The minimal documented binding lives in sdk_patches.py.
+# ---------------------------------------------------------------------------
+
+def test_deeplx_community_client(base_url):
+    pytest.importorskip("deeplx_tr", reason="deeplx-tr client not installed")
+    from . import sdk_patches
+
+    translate = sdk_patches.deeplx_client(base_url)
+    result = translate("hello", source_lang="en", target_lang="de")
+    assert "hello" in result

--- a/test/unittests/test_deeplx_compat.py
+++ b/test/unittests/test_deeplx_compat.py
@@ -1,0 +1,174 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the DeepLX compatibility router."""
+from typing import Dict, List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fake engine
+# ---------------------------------------------------------------------------
+
+class FakeTx:
+    available_languages: List[str] = ["en", "de", "fr", "es"]
+
+    def translate(self, text: str, target: str, source: Optional[str] = None) -> str:
+        return f"[{target}] {text}"
+
+    def detect(self, text: str) -> str:
+        return "en"
+
+    def detect_probs(self, text: str) -> Dict[str, float]:
+        return {"en": 0.95, "de": 0.03, "fr": 0.02}
+
+
+class FakeEngine:
+    plugin_name: str = "fake-translate"
+    langs: List[str] = ["en", "de", "fr", "es"]
+
+    def __init__(self) -> None:
+        self.tx = FakeTx()
+        self.detect = None
+
+
+@pytest.fixture(scope="module")
+def engine():
+    return FakeEngine()
+
+
+@pytest.fixture(scope="module")
+def client(engine):
+    from ovos_translate_server.routers.deeplx import make_deeplx_router
+    app = FastAPI()
+    app.include_router(make_deeplx_router(engine))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# DeepLX  (prefix: /deeplx)
+# ---------------------------------------------------------------------------
+
+class TestDeepLXRouter:
+    def test_translate_basic(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "source_lang": "EN", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+        assert "[de]" in body["data"]
+
+    def test_translate_auto_source(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "source_lang": "auto", "target_lang": "FR"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+        assert "data" in body
+
+    def test_translate_default_source_is_auto(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == 200
+
+    def test_missing_target_lang_rejected(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello"},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_text_rejected(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "", "target_lang": "DE"},
+        )
+        assert resp.status_code == 422
+
+    def test_response_envelope_keys(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "DE"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "code" in body
+        assert "data" in body
+
+    def test_data_is_string(self, client):
+        resp = client.post(
+            "/deeplx/translate",
+            json={"text": "hello", "target_lang": "FR"},
+        )
+        assert resp.status_code == 200
+        assert isinstance(resp.json()["data"], str)
+
+    def test_delegates_to_engine_translate(self, engine):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.deeplx import make_deeplx_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append({"text": text, "target": target, "source": source})
+                return f"[{target}] {text}"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_deeplx_router(eng))
+        c = TestClient(app)
+        c.post("/deeplx/translate", json={"text": "world", "source_lang": "EN", "target_lang": "DE"})
+        assert len(calls) == 1
+        assert calls[0]["text"] == "world"
+        assert calls[0]["target"] == "de"
+        assert calls[0]["source"] == "en"
+
+    def test_auto_source_passes_none_to_engine(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ovos_translate_server.routers.deeplx import make_deeplx_router
+
+        calls = []
+
+        class TrackingTx:
+            available_languages = ["en", "de"]
+
+            def translate(self, text, target, source=None):
+                calls.append(source)
+                return "translated"
+
+        class TrackingEngine:
+            plugin_name = "tracking"
+            langs = ["en", "de"]
+
+            def __init__(self):
+                self.tx = TrackingTx()
+                self.detect = None
+
+        eng = TrackingEngine()
+        app = FastAPI()
+        app.include_router(make_deeplx_router(eng))
+        c = TestClient(app)
+        c.post("/deeplx/translate", json={"text": "hello", "source_lang": "auto", "target_lang": "DE"})
+        assert calls[0] is None


### PR DESCRIPTION
Split of #39 — part 1 of 2 (DeepLX). The Lingva half ships as a separate PR.

## Summary

- Mounts a `/deeplx` router: `POST /deeplx/translate` accepting the DeepLX schema `{text, source_lang, target_lang}` and returning `{code, data}` — distinct from the official DeepL v2 router (`/deepl`). `source_lang: "auto"` triggers auto-detection.
- Registered in `create_app()`.
- `examples/deeplx_example.py` — runnable script (raw HTTP + community-client snippet).

## Docs

- `docs/api-compatibility.md` — prefix, endpoint-reference row, curl examples, "pointing existing clients" subsection.
- `docs/language-codes.md` — DeepLX normalisation (case-insensitive, `auto` sentinel).
- `README.md` — vendor-compatible endpoints section + DeepLX subsection.

## End-to-end tests (official/maintained client)

DeepLX ships **no official Python SDK**. `test/end2end/test_e2e_deeplx.py` boots the full app with a fake engine and exercises `/deeplx`:

- directly over the documented HTTP contract, and
- through the maintained community client **`deeplx-tr`** (its `url` knob points at `/deeplx/translate`), bound in `test/end2end/sdk_patches.py`.

The `test` extra adds `deeplx-tr` and pins `marshmallow<4` (its `environs` dependency breaks on marshmallow 4), so the e2e test imports and **actually runs** rather than being skipped.

## Test plan

- [x] `pytest test/` — 153 passed locally (9 DeepLX unit + 3 DeepLX e2e included)
- [ ] CI green