### PR TITLE
docs: modernize README, docs/, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,100 @@
 # OpenVoiceOS Translate Server
 
-Turn any OVOS Language plugin into a micro service!
+Turn any OVOS language plugin into an HTTP microservice for translation and
+language detection.
 
-Use with OpenVoiceOS [companion plugin](https://github.com/OpenVoiceOS/ovos-translate-server-plugin)
+Pair it with the [companion client plugin](https://github.com/OpenVoiceOS/ovos-translate-server-plugin)
+to offload translation from an OVOS device, or point existing tooling at the
+[vendor-compatible endpoints](#vendor-compatible-endpoints) below.
+
+## Contents
+
+- [Install](#install)
+- [Usage](#usage)
+- [HTTP API](#http-api)
+- [AI Agent Integration](#ai-agent-integration) — UTCP & MCP
+- [Vendor-compatible endpoints](#vendor-compatible-endpoints)
+- [Docker](#docker)
+- [Documentation](#documentation)
+- [Examples](#examples)
+- [Credits](#credits)
 
 ## Install
 
-`pip install ovos-translate-server`
+```bash
+pip install ovos-translate-server
+```
+
+The server only hosts plugins — install at least one translation plugin, and
+optionally a dedicated language-detection plugin, alongside it:
+
+```bash
+pip install ovos-translate-plugin-nllb              # translation
+pip install ovos-lang-detector-classics-plugin      # detection (optional)
+```
+
+Optional extras:
+
+| Extra | Installs | Enables |
+|-------|----------|---------|
+| `mcp` | `pip install "ovos-translate-server[mcp]"` | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` |
+| `lang-names` | `pip install "ovos-translate-server[lang-names]"` | human-readable language names in vendor `languages` responses |
 
 ## Usage
 
 ```bash
-ovos-translate-server --help
-usage: ovos-translate-server [-h] [--tx-engine TX_ENGINE]
-                   [--detect-engine DETECT_ENGINE] [--port PORT] [--host HOST]
+$ ovos-translate-server --help
+usage: ovos-translate-server [-h] --tx-engine TX_ENGINE
+                             [--detect-engine DETECT_ENGINE]
+                             [--host HOST] [--port PORT]
 
-optional arguments:
+Run the OVOS Translate HTTP server.
+
+options:
   -h, --help            show this help message and exit
   --tx-engine TX_ENGINE
-                        translate plugin to be used
+                        OPM translation plugin entry-point name (required)
   --detect-engine DETECT_ENGINE
-                        lang detection plugin to be used
-  --port PORT           port number
-  --host HOST           host
-
+                        OPM language-detection plugin entry-point name (optional)
+  --host HOST           host to bind (default: 0.0.0.0)
+  --port PORT           TCP port (default: 9686)
 ```
 
-eg, to use the [NLLB plugin](https://github.com/OpenVoiceOS/ovos-translate-plugin-nllb) for translation, and [Lang Classifier Classics](https://github.com/OpenVoiceOS/ovos-lang-detector-classics-plugin) for detection
+For example, to serve the [NLLB plugin](https://github.com/OpenVoiceOS/ovos-translate-plugin-nllb)
+for translation and [Lang Classifier Classics](https://github.com/OpenVoiceOS/ovos-lang-detector-classics-plugin)
+for detection:
 
-`ovos-translate-server --tx-engine ovos-translate-plugin-nllb --detect-engine ovos-lang-detector-classics-plugin`
+```bash
+ovos-translate-server \
+  --tx-engine ovos-translate-plugin-nllb \
+  --detect-engine ovos-lang-detector-classics-plugin
+```
 
-then you can do get requests
+When `--detect-engine` is omitted, detection falls back to the translation
+plugin's own `detect()` method. See [docs/detection.md](docs/detection.md).
 
-- `http://0.0.0.0:9686/translate/en/o meu nome é Casimiro` (auto detect source lang)
-- `http://0.0.0.0:9686/translate/pt/en/o meu nome é Casimiro`  (specify source lang)
-- `http://0.0.0.0:9686/detect/o meu nome é Casimiro`
+## HTTP API
+
+The native API is unauthenticated and uses `GET` requests. The text to
+translate or detect is the **last path segment** and should be URL-encoded.
+
+| Method & path | Purpose |
+|---------------|---------|
+| `GET /status` | Plugin name and supported languages |
+| `GET /translate/{target}/{text}` | Translate, auto-detecting the source language |
+| `GET /translate/{source}/{target}/{text}` | Translate with an explicit source language |
+| `GET /detect/{text}` | Detect the language, returns a BCP-47 code |
+| `GET /classify/{text}` | Per-language confidence scores |
+
+```bash
+curl http://localhost:9686/translate/en/o%20meu%20nome%20%C3%A9%20Casimiro
+# "my name is Casimiro"
+
+curl http://localhost:9686/detect/o%20meu%20nome%20%C3%A9%20Casimiro
+# "pt"
+```
+
+Full reference: [docs/index.md](docs/index.md).
 
 ## AI Agent Integration
 
@@ -132,84 +192,78 @@ app, engine = start_translate_server("ovos-translate-plugin-nllb")
 
 ## Vendor-compatible endpoints
 
-The server mounts compat routers so existing tools, SDKs, and scripts that
-already target a commercial translation API can be pointed at your local OVOS
-instance with zero code changes. See [docs/api-compatibility.md](docs/api-compatibility.md)
-for the full reference.
+The server mounts compat routers under per-vendor prefixes so existing tools,
+SDKs, and scripts that already target a commercial translation API can be
+pointed at your local OVOS instance with zero code changes — typically just a
+base-URL / endpoint override, exactly what a DNS redirect to the server would
+achieve.
 
-| Vendor | Prefix | Key endpoints |
-|--------|--------|---------------|
-| DeepL (official SDK) | `/deepl` | `POST /deepl/v2/translate` |
-| LibreTranslate | `/libretranslate` | `POST /libretranslate/translate`, `POST /libretranslate/detect`, `GET /libretranslate/languages` |
-| Lingva Translate | `/lingva` | `GET /lingva/api/v1/{source}/{target}/{query}` |
-| DeepLX | `/deeplx` | `POST /deeplx/translate` |
-| Google Cloud Translation | `/google` | `POST /google/language/translate/v2` |
-| Azure Translator | `/azure` | `POST /azure/translate` |
-| Amazon Translate | `/amazon` | `POST /amazon/translate/text` |
+| Vendor | Prefix | Key endpoints | Client |
+|--------|--------|---------------|--------|
+| DeepL | `/deepl` | `POST /deepl/v2/translate` | official `deepl` SDK |
+| DeepLX | `/deeplx` | `POST /deeplx/translate` | community `deeplx-tr` / HTTP |
+| LibreTranslate | `/libretranslate` | `POST /libretranslate/translate`, `/detect`, `GET /libretranslate/languages` | official `libretranslatepy` |
+| Lingva Translate | `/lingva` | `GET /lingva/api/v1/{source}/{target}/{query}` | HTTP (no SDK) |
+| Google Cloud Translation | `/google` | `POST /google/language/translate/v2` | official `google-cloud-translate` |
+| Azure Translator | `/azure` | `POST /azure/translate` | official `azure-ai-translation-text<2` |
+| Amazon Translate | `/amazon` | `POST /amazon/translate/text` | official `boto3` |
 
-### Lingva Translate
-
-Lingva Translate uses a REST GET endpoint with path parameters.  Use `auto`
-as the source language for automatic detection.
-
-```bash
-curl -s "http://localhost:9686/lingva/api/v1/en/de/hello%20world"
-# {"translation":"..."}
-```
+A runnable script for each lives in [`examples/`](examples/). Full endpoint
+reference, curl examples, and client-configuration snippets:
+[docs/api-compatibility.md](docs/api-compatibility.md).
 
 ```bash
-# Auto-detect source language
-curl -s "http://localhost:9686/lingva/api/v1/auto/fr/bonjour"
-```
-
-Lingva has no official Python SDK; point any HTTP client at the `/lingva`
-prefix.  See `examples/lingva_example.py` for a runnable script.
-
-### DeepLX
-
-DeepLX is an open-source free DeepL-compatible proxy.  Its schema is simpler
-than the official DeepL v2 API: a single endpoint with `{text, source_lang,
-target_lang}` returning `{code, data}`.
-
-```bash
+# DeepLX — simple {text, source_lang, target_lang} -> {code, data}
 curl -s http://localhost:9686/deeplx/translate \
   -H "Content-Type: application/json" \
   -d '{"text": "hello", "source_lang": "EN", "target_lang": "DE"}'
-# {"code":200,"data":"..."}
-```
 
-DeepLX has no official Python SDK; the maintained community client `deeplx-tr`
-can be pointed at this server via its `url` argument.  See
-`examples/deeplx_example.py` for a runnable script.
+# Lingva — GET path params; use "auto" to auto-detect the source
+curl -s "http://localhost:9686/lingva/api/v1/en/de/hello%20world"
+```
 
 ## Docker
 
-you can create easily crete a docker file to serve any plugin
+Any plugin can be served with a small Dockerfile:
 
 ```dockerfile
-FROM python:3.7
+FROM python:3.11-slim
 
-RUN pip3 install ovos-utils==0.0.15
-RUN pip3 install ovos-plugin-manager==0.0.4
-RUN pip3 install ovos-translate-server==0.0.1
+RUN pip install --no-cache-dir \
+    ovos-translate-server \
+    ovos-translate-plugin-nllb \
+    ovos-lang-detector-classics-plugin
 
-RUN pip3 install {PLUGIN_HERE}
-
-ENTRYPOINT ovos-translate-server --tx-engine {PLUGIN_HERE} --detect-engine {PLUGIN_HERE}
+EXPOSE 9686
+ENTRYPOINT ["ovos-translate-server", \
+            "--tx-engine", "ovos-translate-plugin-nllb", \
+            "--detect-engine", "ovos-lang-detector-classics-plugin"]
 ```
 
-build it
+Build and run:
+
 ```bash
-docker build . -t my_ovos_translate_plugin
+docker build -t my-translate-server .
+docker run -p 9686:9686 my-translate-server
 ```
 
-run it
-```bash
-docker run -p 8080:9686 my_ovos_translate_plugin
-```
+Each plugin can ship its own Dockerfile in its repository using
+`ovos-translate-server` as the base.
 
-Each plugin can provide its own Dockerfile in its repository using ovos-translate-server
----
+## Documentation
+
+| Document | Covers |
+|----------|--------|
+| [docs/index.md](docs/index.md) | Overview, installation, native HTTP API, plugin interface |
+| [docs/api-compatibility.md](docs/api-compatibility.md) | Vendor routers — prefixes, endpoints, curl, client configuration |
+| [docs/language-codes.md](docs/language-codes.md) | Per-vendor language-code normalisation |
+| [docs/detection.md](docs/detection.md) | Language-detection priority and per-router behaviour |
+
+## Examples
+
+[`examples/`](examples/) holds one runnable script per vendor router (driving
+each vendor's real client SDK where one exists) plus a native-API script. See
+[examples/README.md](examples/README.md).
 
 ## Credits
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -6,7 +6,7 @@
 
 ## Why Vendor Prefixes?
 
-LibreTranslate and Azure Translator both define `/translate`, `/detect`, and `/languages` at the root level. If all five routers were mounted without a prefix in the same FastAPI app, the last-registered router would silently shadow the earlier ones — resulting in some vendors' endpoints being unreachable.
+LibreTranslate and Azure Translator both define `/translate`, `/detect`, and `/languages` at the root level. If the routers were mounted without a prefix in the same FastAPI app, the last-registered router would silently shadow the earlier ones — resulting in some vendors' endpoints being unreachable.
 
 Every router is therefore mounted under a unique vendor prefix:
 
@@ -20,7 +20,7 @@ Every router is therefore mounted under a unique vendor prefix:
 | Amazon Translate | `/amazon` |
 | Lingva Translate | `/lingva` |
 
-Without these prefixes, `/translate` would be registered five times and only the last registration would be reachable.
+Without these prefixes, `/translate` would be registered by multiple routers and only the last registration would be reachable.
 
 ---
 
@@ -193,14 +193,16 @@ Consider these two real vendor APIs:
 
 Both define identical paths. FastAPI `include_router` adds routes to a shared route table in registration order. The second router's routes would shadow the first's because FastAPI matches the first registered route that fits. The result: Azure routes would be unreachable (registered second) or LibreTranslate routes would be unreachable depending on order — either way, half the API is broken.
 
-The solution implemented in `create_app()` — `ovos_translate_server/__init__.py:88` — is to mount every router with a unique prefix:
+The solution implemented in `create_app()` — `ovos_translate_server/__init__.py` — is to mount every router with a unique prefix:
 
 ```python
-app.include_router(make_libretranslate_router(engine))   # prefix="/libretranslate"
 app.include_router(make_deepl_router(engine))             # prefix="/deepl"
+app.include_router(make_deeplx_router(engine))            # prefix="/deeplx"
+app.include_router(make_libretranslate_router(engine))    # prefix="/libretranslate"
+app.include_router(make_lingva_router(engine))            # prefix="/lingva"
+app.include_router(make_amazon_translate_router(engine))  # prefix="/amazon"
 app.include_router(make_google_translate_router(engine))  # prefix="/google"
 app.include_router(make_azure_translator_router(engine))  # prefix="/azure"
-app.include_router(make_amazon_translate_router(engine))  # prefix="/amazon"
 ```
 
 Each `make_*_router()` factory sets the prefix on the `APIRouter` it returns, so the prefix is co-located with the router definition and cannot be accidentally omitted.

--- a/docs/detection.md
+++ b/docs/detection.md
@@ -1,6 +1,6 @@
 # Language Detection
 
-`ovos-translate-server` exposes language detection through both the native API and all five vendor-compatible routers. This document explains how detection works internally.
+`ovos-translate-server` exposes language detection through both the native API and the vendor-compatible routers. This document explains how detection works internally.
 
 ---
 
@@ -11,7 +11,7 @@ Detection is provided by one of two sources, checked in order:
 1. **Dedicated detection plugin** — loaded when `--detect-engine` is passed on the CLI (or `detect_engine` is passed to `start_translate_server()`). Uses `engine.detect.detect()` / `engine.detect.detect_probs()`.
 2. **Translator fallback** — when no detection plugin is loaded, `engine.tx.detect()` / `engine.tx.detect_probs()` are called on the translator instance.
 
-Source: `ovos_translate_server/__init__.py:113–115`
+Source: the `detect` / `classify` handlers in `create_app()` — `ovos_translate_server/__init__.py`.
 
 ```python
 if engine.detect is not None:
@@ -23,11 +23,11 @@ return engine.tx.detect(utterance)
 
 ## Native Detection Endpoints
 
-### `GET /detect/{utterance}` — `ovos_translate_server/__init__.py:107`
+### `GET /detect/{utterance}`
 
 Returns a single language code string (e.g. `"en"`, `"fr"`).
 
-### `GET /classify/{utterance}` — `ovos_translate_server/__init__.py:117`
+### `GET /classify/{utterance}`
 
 Returns a dict of `{lang_code: confidence_float}` covering all candidate languages. Uses `detect_probs()`.
 
@@ -46,6 +46,8 @@ Each vendor router calls detection slightly differently to match the vendor's re
 | Azure `/translate` | `detect_probs()` (when `from` omitted) | `detectedLanguage.language` + `score` |
 | Azure `/detect` | `detect_probs()` | `language` + `score` per item |
 | Amazon `/translate/text` | `detect()` (when `SourceLanguageCode: "auto"`) | `SourceLanguageCode` in response |
+| DeepLX `/translate` | delegated to the translator (when `source_lang: "auto"`) | not surfaced — response is `{code, data}` only |
+| Lingva `/api/v1/...` | delegated to the translator (when `source: "auto"`) | not surfaced — response is `{translation}` only |
 
 ---
 
@@ -59,7 +61,7 @@ class LanguageDetector:
     def detect_probs(self, text: str) -> dict: ...  # {lang_code: float}
 ```
 
-The `detect_probs()` method must return a dict. If the plugin does not implement it, all compat routers that call `detect_probs()` will raise an `AttributeError` — this is a known gap (see `AUDIT.md`).
+The `detect_probs()` method must return a dict. Routers that surface per-language confidence (LibreTranslate, Google, Azure) call `detect_probs()`, so a detector wired into those paths must implement it — a detector that only provides `detect()` will fail those confidence-bearing responses.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,11 +41,11 @@ CLI arguments:
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `--tx-engine` | required | OPM translation plugin entry-point name |
-| `--detect-engine` | `ovos-lang-detector-classics-plugin` | OPM language detection plugin entry-point name |
+| `--detect-engine` | none | OPM language detection plugin entry-point name (optional) |
 | `--host` | `0.0.0.0` | Host to bind |
 | `--port` | `9686` | TCP port |
 
-If `--detect-engine` is omitted, the server falls back to `ovos-lang-detector-classics-plugin` (must be installed separately).
+If `--detect-engine` is omitted, no dedicated detector is loaded and language detection falls back to the translation plugin's own `detect()` / `detect_probs()` methods. See [detection.md](detection.md).
 
 ### Python API
 
@@ -60,13 +60,13 @@ app, engine = start_translate_server(
 uvicorn.run(app, host="0.0.0.0", port=9686)
 ```
 
-`start_translate_server()` — `ovos_translate_server/__init__.py:155` — loads plugins via `TranslateEngineWrapper`, creates the FastAPI app via `create_app()`, and returns `(app, engine)`. The caller runs the app with `uvicorn.run()`.
+`start_translate_server()` — `ovos_translate_server/__init__.py` — loads plugins via `TranslateEngineWrapper`, creates the FastAPI app via `create_app()`, and returns `(app, engine)`. The caller runs the app with `uvicorn.run()`.
 
 ---
 
 ## HTTP API Endpoints
 
-All endpoints accept `GET` requests. There is no authentication.
+The native endpoints below accept `GET` requests and have no authentication. The vendor-compatible routers add `POST` endpoints under per-vendor prefixes — see [api-compatibility.md](api-compatibility.md).
 
 ### `GET /status`
 
@@ -176,7 +176,7 @@ engine_instance = PluginClass(config=cfg.get(plugin_name, {}))
 
 where `cfg` is `Configuration().get("language", {})` from the OVOS configuration file.
 
-The `TranslateEngineWrapper` — `ovos_translate_server/__init__.py:27` — holds the loaded plugin instances and is injected into the FastAPI route closures via `create_app(engine)` — `ovos_translate_server/__init__.py:79`.
+The `TranslateEngineWrapper` — `ovos_translate_server/__init__.py` — holds the loaded plugin instances and is injected into the FastAPI route closures via `create_app(engine)`.
 
 ---
 

--- a/docs/language-codes.md
+++ b/docs/language-codes.md
@@ -34,7 +34,7 @@ detected_source = engine.detect.detect(item).upper()
 - `target_lang` (e.g. `DE`) → lowercased to `de`
 - `detected_source_language` in the response is always uppercased (e.g. `EN`)
 
-Source: `ovos_translate_server/routers/deepl.py:57–71`
+Source: `ovos_translate_server/routers/deepl.py`
 
 ---
 
@@ -68,7 +68,7 @@ Azure uses the `to` query parameter and an optional `from` parameter. Target cod
 translations.append(AzureTranslation(text=translated or "", to=tgt.upper()))
 ```
 
-Source: `ovos_translate_server/routers/azure_translator.py:103`
+Source: `ovos_translate_server/routers/azure_translator.py`
 
 ---
 
@@ -80,7 +80,7 @@ LibreTranslate clients already use lowercase codes. The router passes them throu
 source = None if request.source == "auto" else request.source
 ```
 
-Source: `ovos_translate_server/routers/libretranslate.py:67`
+Source: `ovos_translate_server/routers/libretranslate.py`
 
 ---
 
@@ -92,7 +92,7 @@ Amazon Translate uses `SourceLanguageCode: "auto"` to request automatic source l
 source = None if request.SourceLanguageCode == "auto" else request.SourceLanguageCode
 ```
 
-Source: `ovos_translate_server/routers/amazon_translate.py:55`
+Source: `ovos_translate_server/routers/amazon_translate.py`
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,41 @@
+# Examples
+
+Runnable scripts that drive a running `ovos-translate-server`. Each vendor
+script points that vendor's **own client** at the matching compat router via a
+base-URL / endpoint override — no request rewriting — which is exactly what a
+DNS redirect to the server would achieve.
+
+## Run a server first
+
+```bash
+pip install ovos-translate-server ovos-translate-plugin-nllb
+ovos-translate-server --tx-engine ovos-translate-plugin-nllb --port 9686
+```
+
+All scripts target `http://localhost:9686` (edit `OVOS_HOST` to change it).
+
+## Scripts
+
+| Script | Drives | Install |
+|--------|--------|---------|
+| `native_example.py` | native `/translate`, `/detect`, `/status` | — (standard library) |
+| `deepl_example.py` | official `deepl` SDK → `/deepl` | `pip install deepl` |
+| `deeplx_example.py` | community `deeplx-tr` client → `/deeplx` | `pip install deeplx-tr` |
+| `libretranslate_example.py` | official `libretranslatepy` → `/libretranslate` | `pip install libretranslatepy` |
+| `lingva_example.py` | HTTP (no SDK exists) → `/lingva` | — (standard library) |
+| `google_example.py` | official `google-cloud-translate` → `/google` | `pip install google-cloud-translate` |
+| `azure_example.py` | official `azure-ai-translation-text` (1.x) → `/azure` | `pip install "azure-ai-translation-text<2"` |
+| `amazon_example.py` | official `boto3` Translate → `/amazon` | `pip install boto3` |
+
+DeepLX and Lingva Translate have no official Python SDK; the former is shown via
+the maintained community `deeplx-tr` client, the latter over plain HTTP.
+
+## Examples
+
+```bash
+python examples/native_example.py translate en "o meu nome é Casimiro"
+python examples/deepl_example.py "hello world" DE
+python examples/deeplx_example.py "hello world" en de
+python examples/lingva_example.py "hello world" en de
+python examples/amazon_example.py "hello world" en de
+```

--- a/examples/deeplx_example.py
+++ b/examples/deeplx_example.py
@@ -1,65 +1,35 @@
-"""Drive a DeepLX-compatible client against an ovos-translate-server instance.
+"""Drive the community deeplx-tr client against ovos-translate-server.
 
-DeepLX exposes a single ``POST /translate`` endpoint that accepts
-``{text, source_lang, target_lang}`` and returns ``{code, data}``.
+DeepLX has no official Python SDK; ``deeplx-tr`` is the maintained community
+client. Point its ``url`` at the ``/deeplx`` router — the same
+``{text, source_lang, target_lang}`` -> ``{code, data}`` contract a real DeepLX
+server speaks. No request rewriting needed.
 
-This compat router is distinct from the official DeepL v2 router (``/deepl``):
-it uses the simpler DeepLX schema, making it a drop-in replacement for
-any tool or script already targeting a DeepLX server.
+    pip install deeplx-tr
+    python examples/deeplx_example.py "hello world" en de
 
-DeepLX is an open-source proxy with **no official Python SDK** (it is consumed
-by CLI tools and browser extensions over plain HTTP), so this example calls the
-HTTP endpoint directly. To drive it with the maintained community client
-instead, install ``deeplx-tr`` and point its ``url`` at this server::
+Without deeplx-tr, the endpoint is plain HTTP:
 
-    from deeplx_tr import deeplx_client
-    deeplx_client("hello", target_lang="de",
-                  url="http://localhost:9686/deeplx/translate")
-
-Prerequisites:
-    ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
-
-Usage:
-    python examples/deeplx_example.py "hello world" DE
-    python examples/deeplx_example.py "bonjour" EN auto
+    curl -s http://localhost:9686/deeplx/translate \\
+      -H 'Content-Type: application/json' \\
+      -d '{"text": "hello world", "source_lang": "en", "target_lang": "de"}'
 """
 import sys
 
-try:
-    import httpx as _http
-
-    def post(url, payload):
-        return _http.post(url, json=payload, timeout=30)
-except ImportError:
-    import urllib.request, json as _json
-
-    class _FakeResp:
-        def __init__(self, data):
-            self._data = data
-
-        def json(self):
-            return self._data
-
-    def post(url, payload):
-        body = _json.dumps(payload).encode()
-        req = urllib.request.Request(url, data=body,
-                                     headers={"Content-Type": "application/json"})
-        with urllib.request.urlopen(req, timeout=30) as r:
-            return _FakeResp(_json.loads(r.read()))
-
+from deeplx_tr import deeplx_client
 
 OVOS_HOST = "http://localhost:9686"
 
 
-def main(text: str, target_lang: str, source_lang: str = "auto") -> None:
-    url = f"{OVOS_HOST}/deeplx/translate"
-    payload = {"text": text, "source_lang": source_lang, "target_lang": target_lang}
-    resp = post(url, payload)
-    body = resp.json()
-    print(f"code={body['code']}  data={body['data']!r}")
+def main(text: str, source: str, target: str) -> None:
+    translated = deeplx_client(
+        text, source_lang=source, target_lang=target,
+        url=f"{OVOS_HOST}/deeplx/translate",
+    )
+    print(translated)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in (3, 4):
-        sys.exit(f"usage: {sys.argv[0]} <text> <TARGET_LANG e.g. DE> [SOURCE_LANG e.g. EN or auto]")
-    main(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) == 4 else "auto")
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <text> <source lang> <target lang>")
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/examples/lingva_example.py
+++ b/examples/lingva_example.py
@@ -1,56 +1,30 @@
-"""Drive a Lingva Translate-compatible client against an ovos-translate-server instance.
+"""Call the Lingva Translate-compatible endpoint on ovos-translate-server.
 
-Lingva Translate uses ``GET /api/v1/{source}/{target}/{query}`` returning
-``{translation}``.  Use ``auto`` as the source language for automatic detection.
+Lingva Translate has no official Python SDK; its REST API is consumed over plain
+HTTP, so this example uses the standard library only. The endpoint is
+``GET /lingva/api/v1/{source}/{target}/{query}`` returning ``{translation}``.
+Use ``auto`` as the source language for automatic detection; the query text must
+be URL-encoded.
 
-Lingva is an open-source Google Translate front end with **no official Python
-SDK** (it is consumed by web/CLI clients over plain HTTP), so this example calls
-the HTTP endpoint directly rather than driving a vendor SDK.
-
-Prerequisites:
-    ovos-translate-server --tx-plugin <some-ovos-translate-plugin> --port 9686
-
-Usage:
-    python examples/lingva_example.py "hello world" de en
-    python examples/lingva_example.py "bonjour le monde" en auto
+    python examples/lingva_example.py "hello world" en de
+    python examples/lingva_example.py "bonjour le monde" auto en
 """
+import json
 import sys
 import urllib.parse
-
-try:
-    import httpx as _http
-
-    def get(url):
-        return _http.get(url, timeout=30)
-except ImportError:
-    import urllib.request, json as _json
-
-    class _FakeResp:
-        def __init__(self, data):
-            self._data = data
-
-        def json(self):
-            return self._data
-
-    def get(url):
-        with urllib.request.urlopen(url, timeout=30) as r:
-            return _FakeResp(_json.loads(r.read()))
-
+import urllib.request
 
 OVOS_HOST = "http://localhost:9686"
 
 
-def main(query: str, target_lang: str, source_lang: str = "auto") -> None:
-    encoded = urllib.parse.quote(query, safe="")
-    url = f"{OVOS_HOST}/lingva/api/v1/{source_lang}/{target_lang}/{encoded}"
-    resp = get(url)
-    body = resp.json()
-    print(f"translation={body['translation']!r}")
+def main(text: str, source: str, target: str) -> None:
+    query = urllib.parse.quote(text, safe="")
+    url = f"{OVOS_HOST}/lingva/api/v1/{source}/{target}/{query}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        print(json.load(resp)["translation"])
 
 
 if __name__ == "__main__":
-    if len(sys.argv) not in (3, 4):
-        sys.exit(
-            f"usage: {sys.argv[0]} <text> <target_lang e.g. de> [source_lang e.g. en or auto]"
-        )
-    main(sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) == 4 else "auto")
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <text> <source lang or 'auto'> <target lang>")
+    main(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/examples/native_example.py
+++ b/examples/native_example.py
@@ -1,0 +1,52 @@
+"""Call the native ovos-translate-server HTTP API (standard library only).
+
+The native API needs no vendor SDK: every endpoint is a ``GET`` with the text as
+the last, URL-encoded path segment.
+
+    GET /translate/{target}/{text}            translate, auto-detect the source
+    GET /translate/{source}/{target}/{text}   translate with an explicit source
+    GET /detect/{text}                        detect the language
+    GET /status                               plugin name + supported languages
+
+Usage:
+    python examples/native_example.py translate en "o meu nome é Casimiro"
+    python examples/native_example.py translate pt en "o meu nome é Casimiro"
+    python examples/native_example.py detect "o meu nome é Casimiro"
+    python examples/native_example.py status
+"""
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+OVOS_HOST = "http://localhost:9686"
+
+
+def _get(path: str):
+    with urllib.request.urlopen(f"{OVOS_HOST}{path}", timeout=30) as resp:
+        return json.load(resp)
+
+
+def _seg(text: str) -> str:
+    return urllib.parse.quote(text, safe="")
+
+
+def main(argv: list) -> None:
+    cmd = argv[0] if argv else ""
+
+    if cmd == "status" and len(argv) == 1:
+        print(json.dumps(_get("/status"), ensure_ascii=False))
+    elif cmd == "detect" and len(argv) == 2:
+        print(_get(f"/detect/{_seg(argv[1])}"))
+    elif cmd == "translate" and len(argv) == 3:
+        target, text = argv[1], argv[2]
+        print(_get(f"/translate/{target}/{_seg(text)}"))
+    elif cmd == "translate" and len(argv) == 4:
+        source, target, text = argv[1], argv[2], argv[3]
+        print(_get(f"/translate/{source}/{target}/{_seg(text)}"))
+    else:
+        sys.exit(__doc__)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Documentation-only modernization pass over `README.md`, `docs/`, and `examples/` — no code changes. Now that all seven vendor routers (incl. DeepLX & Lingva from #44/#45) are on `dev`, this brings the prose, references, and runnable scripts up to date.

## README
- Add a table of contents, an optional-extras table (`mcp`, `lang-names`), and a **Documentation** index linking every `docs/` page.
- Accurate `--help` output (modern `options:` heading, `--tx-engine` shown required) and a **native HTTP API** quick-reference table.
- Reorder the vendor-compatible table and annotate each row with its client (official SDK / community / HTTP).
- Replace the EOL `python:3.7` Dockerfile and its ancient pinned versions (`ovos-utils==0.0.15`, …) with a `python:3.11-slim` image + exec-form `ENTRYPOINT` + matching `9686` port; fix the "crete" typo.
- Credits / NGI0 attribution preserved verbatim.

## docs/
- Replace brittle exact line-number references (`__init__.py:88`, `azure_translator.py:103`, …) with durable **symbol references** — the numbers had already drifted (e.g. `create_app` is at L77, not L79; azure ref pointed at L103 but the code is at L110).
- Fix stale **"five routers"** wording, list all routers in the path-conflict example, and add **DeepLX/Lingva** rows to the detection table.
- Drop the dangling **`AUDIT.md`** reference (file does not exist) and reword the `detect_probs()` caveat factually.
- Correct the `--detect-engine` default: **none** (falls back to the translator's own `detect()`), matching the code rather than claiming an automatic classics-plugin fallback.

## examples/
- Add **`examples/README.md`** (index + how to run) and a stdlib **`native_example.py`** covering `/translate`, `/detect`, `/status`.
- Make `deeplx_example.py` (community `deeplx-tr` client) and `lingva_example.py` (stdlib HTTP) lean and consistent with the five official-SDK scripts.

## Verification
- All 8 example scripts byte-compile; `native_example.py`, `lingva_example.py`, and `deeplx_example.py` were run end-to-end against a booted server (fake engine) — all return expected output.
- All README relative links resolve to existing files.