### PR TITLE
fix: detect the source language on the auto-source translate route

### DIFF
--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -84,6 +84,26 @@ class TranslateEngineWrapper:
             self.detect = detect_cls(config=self._plugin_config("language_detection", detect_plugin))
             self.detect_plugin_name = detect_plugin
 
+    def translate_auto_source(self, utterance: str, tgt_lang: str) -> str:
+        """
+        Translate *utterance* into *tgt_lang* without being told its language.
+
+        Only some engines detect the source themselves; others (e.g. the NLLB
+        plugin) reject an empty source outright, which made this route fail for
+        them. When a detection plugin is configured, use it to resolve the
+        source first, then hand both languages to the translator. Falls back to
+        letting the engine try on its own when no detector is available.
+        """
+        if self.detect is not None:
+            try:
+                src_lang = self.detect.detect(utterance)
+                if src_lang:
+                    return self.tx.translate(utterance, target=tgt_lang,
+                                             source=src_lang)
+            except Exception as err:  # detection is best-effort
+                LOG.warning(f"source language detection failed: {err}")
+        return self.tx.translate(utterance, target=tgt_lang)
+
     @property
     def langs(self) -> List[str]:
         """Return languages supported by the translation plugin."""
@@ -144,7 +164,7 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
     @app.get("/translate/{tgt_lang}/{utterance}")
     def translate_auto(tgt_lang: str, utterance: str) -> str:
         """Translate *utterance* to *tgt_lang*, auto-detecting the source language."""
-        return engine.tx.translate(utterance, target=tgt_lang)
+        return engine.translate_auto_source(utterance, tgt_lang)
 
     @app.get("/translate/{src_lang}/{tgt_lang}/{utterance}")
     def translate(src_lang: str, tgt_lang: str, utterance: str) -> str:

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -14,6 +14,7 @@ from typing import List, Optional, Tuple
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from ovos_config import Configuration
 from ovos_plugin_manager.language import load_lang_detect_plugin, load_tx_plugin
 from ovos_plugin_manager.templates.language import LanguageDetector, LanguageTranslator
 from ovos_utils.log import LOG
@@ -30,6 +31,18 @@ class TranslateEngineWrapper:
         plugin_name: Entry-point name of the translation plugin.
         detect_plugin_name: Entry-point name of the detection plugin, or ``None``.
     """
+
+    @staticmethod
+    def _plugin_config(section: str, plugin: str) -> dict:
+        """
+        Return the plugin's own config section from mycroft.conf.
+
+        Mirrors how OVOSLangTranslationFactory/OVOSLangDetectionFactory resolve
+        plugin settings, so a server started from the CLI still honours a
+        mounted mycroft.conf. Returns an empty dict when nothing is configured.
+        """
+        cfg = Configuration()
+        return cfg.get(section, {}).get(plugin) or cfg.get(plugin) or {}
 
     def __init__(self, tx_plugin: str, detect_plugin: Optional[str] = None) -> None:
         """Load plugins and prepare them for serving.
@@ -54,7 +67,10 @@ class TranslateEngineWrapper:
         tx_cls = load_tx_plugin(tx_plugin)
         if tx_cls is None:
             raise ImportError(f"{tx_plugin} failed to load, is it installed?")
-        self.tx: LanguageTranslator = tx_cls(config={})
+        # match OVOSLangTranslationFactory behaviour: read the plugin's own
+        # section from mycroft.conf, so a mounted config can select the model,
+        # device, beam size etc. instead of always getting plugin defaults.
+        self.tx: LanguageTranslator = tx_cls(config=self._plugin_config("translation", tx_plugin))
         self.plugin_name: str = tx_plugin
 
         self.detect: Optional[LanguageDetector] = None
@@ -65,7 +81,7 @@ class TranslateEngineWrapper:
                 raise ImportError(
                     f"{detect_plugin} failed to load, is it installed?"
                 )
-            self.detect = detect_cls(config={})
+            self.detect = detect_cls(config=self._plugin_config("language_detection", detect_plugin))
             self.detect_plugin_name = detect_plugin
 
     @property

--- a/ovos_translate_server/mcp_server.py
+++ b/ovos_translate_server/mcp_server.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+    from mcp.server.mcpserver import MCPServer  # type: ignore[import-untyped]
     from starlette.applications import Starlette
     from ovos_translate_server import TranslateEngineWrapper
 
@@ -47,8 +47,8 @@ __all__ = [
 ]
 
 
-def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":
-    """Build and return a :class:`~mcp.server.fastmcp.FastMCP` instance.
+def build_mcp(engine: "TranslateEngineWrapper") -> "MCPServer":
+    """Build and return a :class:`~mcp.server.mcpserver.MCPServer` instance.
 
     The instance exposes *translate* and *detect_language* tools backed by the
     supplied *engine*.
@@ -57,20 +57,26 @@ def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":
         engine: An initialised :class:`~ovos_translate_server.TranslateEngineWrapper`.
 
     Returns:
-        A configured ``FastMCP`` server (not yet started).
+        A configured ``MCPServer`` instance (not yet started).
 
     Raises:
         ImportError: If the ``mcp`` package is not installed.
     """
     try:
-        from mcp.server.fastmcp import FastMCP
-    except ImportError as exc:
-        raise ImportError(
-            "The 'mcp' package is required for MCP support. "
-            "Install it with: pip install 'ovos-translate-server[mcp]'"
-        ) from exc
+        # ``FastMCP`` was renamed to ``MCPServer`` and moved to
+        # ``mcp.server.mcpserver`` in newer releases of the ``mcp`` SDK; fall
+        # back to the older import path for pre-rename installs.
+        from mcp.server.mcpserver import MCPServer
+    except ImportError:
+        try:
+            from mcp.server.fastmcp import FastMCP as MCPServer  # type: ignore[import-untyped,assignment]
+        except ImportError as exc:
+            raise ImportError(
+                "The 'mcp' package is required for MCP support. "
+                "Install it with: pip install 'ovos-translate-server[mcp]'"
+            ) from exc
 
-    mcp = FastMCP(
+    mcp = MCPServer(
         name="ovos-translate",
         instructions=(
             "Translation and language-detection service backed by an "
@@ -169,8 +175,7 @@ def mount_mcp(
 
     mcp = build_mcp(engine)
     # Serve at the mount root so the endpoint is exactly *path*.
-    mcp.settings.streamable_http_path = "/"
-    app.mount(path, mcp.streamable_http_app())
+    app.mount(path, mcp.streamable_http_app(streamable_http_path="/"))
 
     # Chain the MCP session manager into the host app lifespan so the
     # transport is active for the lifetime of the server process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ mcp = ["mcp>=1.0.0"]
 # deeplx-tr is the maintained community client for DeepLX (no official SDK exists);
 # it pulls `environs`, which breaks on marshmallow>=4, hence the pin so the DeepLX
 # e2e test imports and actually runs instead of being silently skipped.
-test = ["pytest", "httpx", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy", "deeplx-tr", "marshmallow<4"]
+# httpx<1 pins below the 1.0 dev prereleases, which drop the `timeout` kwarg
+# from httpx.get()/post() and break the e2e test server-readiness polling.
+test = ["pytest", "httpx<1", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy", "deeplx-tr", "marshmallow<4"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-translate-server"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "ovos-plugin-manager",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/test/end2end/test_e2e_mcp_utcp.py
+++ b/test/end2end/test_e2e_mcp_utcp.py
@@ -211,7 +211,9 @@ class TestMcpE2E:
         from mcp import ClientSession
 
         async def _run():
-            async with streamable_http_client(mcp_server) as (r, w, _):
+            # mcp>=1.27 dropped the third (get_session_id) yielded value.
+            async with streamable_http_client(mcp_server) as streams:
+                r, w = streams[0], streams[1]
                 async with ClientSession(r, w) as session:
                     await session.initialize()
                     result = await session.list_tools()
@@ -226,7 +228,9 @@ class TestMcpE2E:
         from mcp import ClientSession
 
         async def _run():
-            async with streamable_http_client(mcp_server) as (r, w, _):
+            # mcp>=1.27 dropped the third (get_session_id) yielded value.
+            async with streamable_http_client(mcp_server) as streams:
+                r, w = streams[0], streams[1]
                 async with ClientSession(r, w) as session:
                     await session.initialize()
                     tools = await session.list_tools()

--- a/test/end2end/test_e2e_translate.py
+++ b/test/end2end/test_e2e_translate.py
@@ -62,6 +62,14 @@ class _FakeEngine:
         self.tx = _FakeTx()
         self.detect = _FakeDetect()
 
+    def translate_auto_source(self, utterance: str, tgt_lang: str) -> str:
+        """Mirror TranslateEngineWrapper.translate_auto_source: resolve the
+        source language via the detect plugin first, then translate."""
+        src_lang = self.detect.detect(utterance)
+        if src_lang:
+            return self.tx.translate(utterance, target=tgt_lang, source=src_lang)
+        return self.tx.translate(utterance, target=tgt_lang)
+
 
 def _free_port() -> int:
     with socket.socket() as s:

--- a/test/unittests/test_auto_source_detection.py
+++ b/test/unittests/test_auto_source_detection.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0
+"""The auto-source route resolves the source language before translating.
+
+Regression test: /translate/{tgt}/{utterance} passed no source at all, so
+engines that cannot detect it themselves (e.g. ovos-translate-plugin-nllb,
+which raises ValueError on an empty source) failed every request on this
+route even when a detection plugin was configured.
+"""
+from unittest.mock import MagicMock, patch
+
+
+def _wrapper(detect=None, tx_side_effect=None):
+    tx = MagicMock()
+    tx.translate = MagicMock(side_effect=tx_side_effect, return_value="ok")
+    with patch("ovos_translate_server.Configuration", return_value={}), \
+         patch("ovos_translate_server.load_tx_plugin", return_value=lambda config=None: tx), \
+         patch("ovos_translate_server.load_lang_detect_plugin",
+               return_value=(lambda config=None: detect) if detect else None):
+        from ovos_translate_server import TranslateEngineWrapper
+        w = TranslateEngineWrapper("tx-plugin", "detect-plugin" if detect else None)
+    return w, tx
+
+
+def test_detected_source_is_passed_to_translator():
+    det = MagicMock()
+    det.detect = MagicMock(return_value="pt")
+    w, tx = _wrapper(detect=det)
+    w.translate_auto_source("bom dia", "en")
+    tx.translate.assert_called_once_with("bom dia", target="en", source="pt")
+
+
+def test_without_detector_engine_is_left_to_cope():
+    w, tx = _wrapper(detect=None)
+    w.translate_auto_source("bom dia", "en")
+    tx.translate.assert_called_once_with("bom dia", target="en")
+
+
+def test_detection_failure_falls_back_instead_of_500ing():
+    det = MagicMock()
+    det.detect = MagicMock(side_effect=RuntimeError("detector exploded"))
+    w, tx = _wrapper(detect=det)
+    w.translate_auto_source("bom dia", "en")
+    tx.translate.assert_called_once_with("bom dia", target="en")
+
+
+def test_empty_detection_falls_back():
+    det = MagicMock()
+    det.detect = MagicMock(return_value="")
+    w, tx = _wrapper(detect=det)
+    w.translate_auto_source("bom dia", "en")
+    tx.translate.assert_called_once_with("bom dia", target="en")

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -57,12 +57,16 @@ mcp = pytest.importorskip("mcp", reason="mcp package not installed")
 
 class TestBuildMcp:
     def test_build_mcp_returns_fastmcp(self):
-        from mcp.server.fastmcp import FastMCP
+        try:
+            # renamed from FastMCP -> MCPServer in newer mcp SDK releases
+            from mcp.server.mcpserver import MCPServer as _MCPCls
+        except ImportError:
+            from mcp.server.fastmcp import FastMCP as _MCPCls
         from ovos_translate_server.mcp_server import build_mcp
 
         engine = FakeEngine()
         server = build_mcp(engine)
-        assert isinstance(server, FastMCP)
+        assert isinstance(server, _MCPCls)
 
     def test_mcp_registers_translate_tool(self):
         from ovos_translate_server.mcp_server import build_mcp
@@ -175,7 +179,12 @@ class TestBuildMcpImportError:
         import sys
         from unittest.mock import patch
 
-        with patch.dict(sys.modules, {"mcp": None, "mcp.server": None, "mcp.server.fastmcp": None}):
+        with patch.dict(sys.modules, {
+            "mcp": None,
+            "mcp.server": None,
+            "mcp.server.fastmcp": None,
+            "mcp.server.mcpserver": None,
+        }):
             # Re-import to bypass module cache
             import importlib
             import ovos_translate_server.mcp_server as _mod
@@ -309,12 +318,15 @@ class TestMountMcp:
         assert host.router.lifespan_context is not original_lifespan
 
     def test_mount_mcp_sets_streamable_http_path(self):
-        """The MCP settings.streamable_http_path must be "/" after mount_mcp."""
+        """The mounted sub-app must serve the MCP endpoint at exactly *path*,
+        i.e. the sub-app's internal route is "/" rather than "/mcp", so the
+        combined route does not become "/mcp/mcp"."""
         from fastapi import FastAPI
-        from ovos_translate_server.mcp_server import build_mcp
+        from ovos_translate_server.mcp_server import mount_mcp
 
-        mcp = build_mcp(FakeEngine())
-        mcp.settings.streamable_http_path = "/mcp"  # simulate un-patched state
-        assert mcp.settings.streamable_http_path != "/"
-        mcp.settings.streamable_http_path = "/"
-        assert mcp.settings.streamable_http_path == "/"
+        host = FastAPI()
+        mount_mcp(host, FakeEngine(), path="/mcp")
+
+        mount_route = next(r for r in host.routes if getattr(r, "path", None) == "/mcp")
+        sub_paths = [r.path for r in mount_route.app.routes]
+        assert sub_paths == ["/"]

--- a/test/unittests/test_plugin_config_resolution.py
+++ b/test/unittests/test_plugin_config_resolution.py
@@ -1,0 +1,52 @@
+# Licensed under the Apache License, Version 2.0
+"""TranslateEngineWrapper resolves plugin config from mycroft.conf.
+
+Regression test: the wrapper used to pass ``config={}`` to both plugins, so a
+mounted mycroft.conf selecting a model, device or beam size was ignored and the
+server always ran plugin defaults.
+"""
+from unittest.mock import MagicMock, patch
+
+TX = "ovos-translate-plugin-nllb"
+DET = "ovos-fake-detect-plugin"
+CONF = {
+    "translation": {TX: {"model": "nllb-200_600M_int8", "device": "cuda"}},
+    "language_detection": {DET: {"model": "fake-lid"}},
+}
+
+
+def _cls(captured, key):
+    def factory(config=None, **kwargs):
+        captured[key] = config
+        return MagicMock()
+    return factory
+
+
+def _build(conf):
+    captured = {}
+    with patch("ovos_translate_server.Configuration", return_value=conf), \
+         patch("ovos_translate_server.load_tx_plugin", return_value=_cls(captured, "tx")), \
+         patch("ovos_translate_server.load_lang_detect_plugin", return_value=_cls(captured, "detect")):
+        from ovos_translate_server import TranslateEngineWrapper
+        TranslateEngineWrapper(TX, DET)
+    return captured
+
+
+def test_translator_gets_its_config_section():
+    assert _build(CONF)["tx"] == {"model": "nllb-200_600M_int8", "device": "cuda"}
+
+
+def test_detector_gets_its_config_section():
+    assert _build(CONF)["detect"] == {"model": "fake-lid"}
+
+
+def test_missing_section_yields_empty_dict():
+    captured = _build({})
+    assert captured["tx"] == {}
+    assert captured["detect"] == {}
+
+
+def test_flat_toplevel_section_also_honoured():
+    # some configs put the plugin section at the top level rather than nested
+    captured = _build({TX: {"device": "cuda"}})
+    assert captured["tx"] == {"device": "cuda"}


### PR DESCRIPTION
`GET /translate/{tgt_lang}/{utterance}` — the "auto-detect the source" route — passed **no source at all** to the translation plugin, assuming every engine resolves it internally. `ovos-translate-plugin-nllb` does not; it raises `ValueError: Invalid source language:` on an empty source. So that route 500s on every request for NLLB-backed servers, even when a detection plugin is configured and working.

Now the wrapper uses the configured detector to resolve the source, then passes both languages through. Detection is best-effort — on failure or empty result it falls back to the old call, so engines with their own auto-detect (e.g. the Google plugin, which takes `sl=auto`) are unaffected.

Found while bringing up an NLLB demo server. 4 regression tests; 121 tests pass.

Branched on top of #51 (config from mycroft.conf) since both are needed to run NLLB behind this server; happy to rebase once that merges.

## Model usage
Authored by Claude (Fable 5); failure reproduced live against a running NLLB container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)