### PR TITLE
refactor: migrate MCP server to the fastmcp package

### DIFF
--- a/ovos_translate_server/mcp_server.py
+++ b/ovos_translate_server/mcp_server.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+    from fastmcp import FastMCP  # type: ignore[import-untyped]
     from starlette.applications import Starlette
     from ovos_translate_server import TranslateEngineWrapper
 
@@ -48,7 +48,7 @@ __all__ = [
 
 
 def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":
-    """Build and return a :class:`~mcp.server.fastmcp.FastMCP` instance.
+    """Build and return a :class:`~fastmcp.FastMCP` instance.
 
     The instance exposes *translate* and *detect_language* tools backed by the
     supplied *engine*.
@@ -60,13 +60,13 @@ def build_mcp(engine: "TranslateEngineWrapper") -> "FastMCP":
         A configured ``FastMCP`` server (not yet started).
 
     Raises:
-        ImportError: If the ``mcp`` package is not installed.
+        ImportError: If the ``fastmcp`` package is not installed.
     """
     try:
-        from mcp.server.fastmcp import FastMCP
+        from fastmcp import FastMCP
     except ImportError as exc:
         raise ImportError(
-            "The 'mcp' package is required for MCP support. "
+            "The 'fastmcp' package is required for MCP support. "
             "Install it with: pip install 'ovos-translate-server[mcp]'"
         ) from exc
 
@@ -137,7 +137,7 @@ def get_mcp_app(engine: "TranslateEngineWrapper") -> "Starlette":
         Starlette ASGI application serving the MCP protocol at the root path.
     """
     mcp = build_mcp(engine)
-    return mcp.streamable_http_app()
+    return mcp.http_app(path="/")
 
 
 
@@ -148,16 +148,17 @@ def mount_mcp(
 ) -> None:
     """Mount the MCP streamable-HTTP transport on *app* at *path*.
 
-    Two things that a plain ``app.mount(path, mcp.streamable_http_app())`` call
-    gets wrong:
+    Two things that a plain ``app.mount(path, mcp.http_app())`` call gets
+    wrong:
 
     1. FastMCP defaults its internal endpoint to ``/mcp``, so mounting at
        ``/mcp`` would surface the protocol at ``/mcp/mcp``.  This function
-       overrides that to ``"/"`` so the endpoint lands at exactly *path*.
+       builds the sub-app with ``path="/"`` so the endpoint lands at exactly
+       *path*.
     2. Starlette does not propagate lifespan events to mounted sub-apps, but
-       the streamable transport requires ``mcp.session_manager`` to be running.
-       This function wraps the host app's existing lifespan to co-start the
-       session manager.
+       the streamable transport requires the MCP sub-app's own lifespan (which
+       starts its session manager) to be running.  This function wraps the
+       host app's existing lifespan to co-start it.
 
     Args:
         app: The :class:`~fastapi.FastAPI` host application.
@@ -169,17 +170,18 @@ def mount_mcp(
 
     mcp = build_mcp(engine)
     # Serve at the mount root so the endpoint is exactly *path*.
-    mcp.settings.streamable_http_path = "/"
-    app.mount(path, mcp.streamable_http_app())
+    mcp_app = mcp.http_app(path="/")
+    app.mount(path, mcp_app)
 
-    # Chain the MCP session manager into the host app lifespan so the
+    # Chain the MCP sub-app's lifespan into the host app lifespan so the
     # transport is active for the lifetime of the server process.
     _original_lifespan = app.router.lifespan_context
+    _mcp_lifespan = mcp_app.router.lifespan_context
 
     @asynccontextmanager
     async def _lifespan_with_mcp(host_app):
         async with _original_lifespan(host_app):
-            async with mcp.session_manager.run():
+            async with _mcp_lifespan(mcp_app):
                 yield
 
     app.router.lifespan_context = _lifespan_with_mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 lang-names = ["langcodes"]
-mcp = ["mcp>=1.0.0"]
+mcp = ["fastmcp>=3,<4"]
 # deeplx-tr is the maintained community client for DeepLX (no official SDK exists);
 # it pulls `environs`, which breaks on marshmallow>=4, hence the pin so the DeepLX
 # e2e test imports and actually runs instead of being silently skipped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ mcp = ["fastmcp>=3,<4"]
 # deeplx-tr is the maintained community client for DeepLX (no official SDK exists);
 # it pulls `environs`, which breaks on marshmallow>=4, hence the pin so the DeepLX
 # e2e test imports and actually runs instead of being silently skipped.
-test = ["pytest", "httpx", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy", "deeplx-tr", "marshmallow<4"]
+test = ["pytest", "httpx", "httpx2", "python-multipart", "uvicorn", "deepl", "google-cloud-translate", "azure-ai-translation-text<2", "boto3", "libretranslatepy", "deeplx-tr", "marshmallow<4"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-translate-server"

--- a/test/end2end/test_e2e_mcp_utcp.py
+++ b/test/end2end/test_e2e_mcp_utcp.py
@@ -128,7 +128,7 @@ def mcp_server():
 
     stub = _StubTranslateEngine()
     mcp = build_mcp(stub)
-    mcp_app = mcp.streamable_http_app()
+    mcp_app = mcp.http_app()
     try:
         base_url, server, thread = _start_server(mcp_app, health_path="/mcp")
     except RuntimeError as exc:
@@ -191,10 +191,10 @@ class TestUtcpE2E:
 # MCP end-to-end
 # ---------------------------------------------------------------------------
 
-_mcp_available = importlib.util.find_spec("mcp") is not None
+_mcp_available = importlib.util.find_spec("fastmcp") is not None
 mcp_required = pytest.mark.skipif(
     not _mcp_available,
-    reason="mcp package not installed",
+    reason="fastmcp package not installed",
 )
 
 

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -2,12 +2,18 @@
 """Unit tests for the MCP server module.
 
 All tests mock the translation plugin so no OPM plugin needs to be installed.
-The ``mcp`` package must be installed (``pip install mcp``).
+The ``fastmcp`` package must be installed (``pip install fastmcp``).
 """
+import asyncio
 from typing import Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _list_tools(server):
+    """Synchronously fetch the list of registered tools from a FastMCP server."""
+    return asyncio.run(server.list_tools())
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +54,7 @@ class FakeEngine:
 # Import guard — skip tests if mcp is not installed
 # ---------------------------------------------------------------------------
 
-mcp = pytest.importorskip("mcp", reason="mcp package not installed")
+mcp = pytest.importorskip("fastmcp", reason="fastmcp package not installed")
 
 
 # ---------------------------------------------------------------------------
@@ -57,7 +63,7 @@ mcp = pytest.importorskip("mcp", reason="mcp package not installed")
 
 class TestBuildMcp:
     def test_build_mcp_returns_fastmcp(self):
-        from mcp.server.fastmcp import FastMCP
+        from fastmcp import FastMCP
         from ovos_translate_server.mcp_server import build_mcp
 
         engine = FakeEngine()
@@ -69,7 +75,7 @@ class TestBuildMcp:
 
         engine = FakeEngine()
         server = build_mcp(engine)
-        tool_names = [t.name for t in server._tool_manager.list_tools()]
+        tool_names = [t.name for t in _list_tools(server)]
         assert "translate" in tool_names
 
     def test_mcp_registers_detect_language_tool(self):
@@ -77,7 +83,7 @@ class TestBuildMcp:
 
         engine = FakeEngine()
         server = build_mcp(engine)
-        tool_names = [t.name for t in server._tool_manager.list_tools()]
+        tool_names = [t.name for t in _list_tools(server)]
         assert "detect_language" in tool_names
 
     def test_mcp_has_exactly_two_tools(self):
@@ -85,7 +91,7 @@ class TestBuildMcp:
 
         engine = FakeEngine()
         server = build_mcp(engine)
-        assert len(server._tool_manager.list_tools()) == 2
+        assert len(_list_tools(server)) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +106,7 @@ class TestTranslateTool:
 
     def _get_tool_fn(self, server, name: str):
         """Retrieve the raw callable registered under *name*."""
-        for tool in server._tool_manager.list_tools():
+        for tool in _list_tools(server):
             if tool.name == name:
                 return tool.fn
         raise KeyError(name)
@@ -143,7 +149,7 @@ class TestDetectLanguageTool:
         return build_mcp(FakeEngine(with_detect=False))
 
     def _get_detect_fn(self, server):
-        for tool in server._tool_manager.list_tools():
+        for tool in _list_tools(server):
             if tool.name == "detect_language":
                 return tool.fn
         raise KeyError("detect_language")
@@ -167,21 +173,21 @@ class TestDetectLanguageTool:
 
 
 # ---------------------------------------------------------------------------
-# ImportError path — mcp not installed
+# ImportError path — fastmcp not installed
 # ---------------------------------------------------------------------------
 
 class TestBuildMcpImportError:
-    def test_import_error_raised_when_mcp_missing(self):
+    def test_import_error_raised_when_fastmcp_missing(self):
         import sys
         from unittest.mock import patch
 
-        with patch.dict(sys.modules, {"mcp": None, "mcp.server": None, "mcp.server.fastmcp": None}):
+        with patch.dict(sys.modules, {"fastmcp": None}):
             # Re-import to bypass module cache
             import importlib
             import ovos_translate_server.mcp_server as _mod
             importlib.reload(_mod)
 
-            with pytest.raises(ImportError, match="mcp"):
+            with pytest.raises(ImportError, match="fastmcp"):
                 _mod.build_mcp(FakeEngine())
 
         # Restore real module
@@ -213,7 +219,7 @@ class TestTranslateToolEdgeCases:
         return build_mcp(FakeEngine())
 
     def _get_fn(self, server, name):
-        for tool in server._tool_manager.list_tools():
+        for tool in _list_tools(server):
             if tool.name == name:
                 return tool.fn
         raise KeyError(name)
@@ -249,7 +255,7 @@ class TestTranslateToolEdgeCases:
                     return "en"
 
         server = build_mcp(BrokenEngine())
-        for tool in server._tool_manager.list_tools():
+        for tool in _list_tools(server):
             if tool.name == "translate":
                 fn = tool.fn
                 break
@@ -275,7 +281,7 @@ class TestTranslateToolEdgeCases:
                     raise RuntimeError("detect failed")
 
         server = build_mcp(BrokenEngine())
-        for tool in server._tool_manager.list_tools():
+        for tool in _list_tools(server):
             if tool.name == "detect_language":
                 fn = tool.fn
                 break
@@ -308,13 +314,13 @@ class TestMountMcp:
         mount_mcp(host, FakeEngine(), path="/mcp")
         assert host.router.lifespan_context is not original_lifespan
 
-    def test_mount_mcp_sets_streamable_http_path(self):
-        """The MCP settings.streamable_http_path must be "/" after mount_mcp."""
+    def test_mount_mcp_serves_at_exact_path(self):
+        """The MCP sub-app must be built with path="/" so the endpoint lands
+        at exactly the *path* it is mounted under, not *path*/mcp."""
         from fastapi import FastAPI
         from ovos_translate_server.mcp_server import build_mcp
 
         mcp = build_mcp(FakeEngine())
-        mcp.settings.streamable_http_path = "/mcp"  # simulate un-patched state
-        assert mcp.settings.streamable_http_path != "/"
-        mcp.settings.streamable_http_path = "/"
-        assert mcp.settings.streamable_http_path == "/"
+        mcp_app = mcp.http_app(path="/")
+        sub_app_paths = [r.path for r in mcp_app.routes]
+        assert "/" in sub_app_paths


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

mcp 2.x removed its bundled mcp.server.fastmcp module. fastmcp (Apache-2.0) is the maintained continuation of that same server class, so ovos_translate_server/mcp_server.py now imports FastMCP from fastmcp instead. The mcp extra keeps its old name but now installs fastmcp>=3,<4. build_mcp, get_mcp_app, and mount_mcp were ported to the new API: list_tools() and get_tool() are async now, streamable_http_app() became http_app(), and lifespan chaining for the mounted sub-app replaces the removed session_manager.run(). None of this changes what a client sees — the /mcp and /utcp routes and the wire protocol are exactly the same as before.

Verified with an in-process smoke test that builds the server, lists its tools (translate and detect_language), and calls translate directly, getting back the expected translated text. The standalone stdio entry point (python -m ovos_translate_server.mcp_server) was also started directly and confirmed to block on stdin as expected, the normal behavior for that transport.

test/unittests/test_mcp_server.py is 20 passed, and test/end2end/test_e2e_mcp_utcp.py is 9 passed, covering a real HTTP round trip of list_tools and call_tool through the streamable-HTTP transport. The full suite is 163 passed, with no tests skipped.
