### PR TITLE
feat: make MCP mounting opt-in via --mcp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Optional extras:
 
 | Extra | Installs | Enables |
 |-------|----------|---------|
-| `mcp` | `pip install "ovos-translate-server[mcp]"` | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` |
+| `mcp` | `pip install "ovos-translate-server[mcp]"` + `--mcp` flag | embedded [MCP](#mcp--model-context-protocol) server at `/mcp` |
 | `lang-names` | `pip install "ovos-translate-server[lang-names]"` | human-readable language names in vendor `languages` responses |
 
 ## Usage
@@ -132,16 +132,20 @@ registered when the server starts.
 
 ### MCP — Model Context Protocol
 
-An optional [MCP](https://modelcontextprotocol.io) server is embedded in
-the main application when the `mcp` extra is installed:
+An optional [MCP](https://modelcontextprotocol.io) server can be embedded in
+the main application when the `mcp` extra is installed **and** the server is
+started with `--mcp`:
 
 ```bash
 pip install "ovos-translate-server[mcp]"
+ovos-translate-server --tx-engine ovos-translate-plugin-nllb --mcp
 ```
 
-Once installed, the MCP endpoint is automatically mounted at `/mcp` using
-the Streamable HTTP transport.  Agents that speak MCP (Claude Desktop,
-Continue, etc.) can add it as a server at:
+Installing the extra alone does not mount `/mcp` — the flag is required, so
+that installing an extra never silently exposes a tool endpoint. With the
+flag passed, the MCP endpoint is mounted at `/mcp` using the Streamable HTTP
+transport.  Agents that speak MCP (Claude Desktop, Continue, etc.) can add it
+as a server at:
 
 ```
 http://localhost:9686/mcp
@@ -173,7 +177,7 @@ python -m ovos_translate_server.mcp_server \
 from ovos_translate_server import start_translate_server
 from ovos_translate_server.mcp_server import get_mcp_app
 
-app, engine = start_translate_server("ovos-translate-plugin-nllb")
+app, engine = start_translate_server("ovos-translate-plugin-nllb", enable_mcp=True)
 # MCP is already mounted at /mcp; or mount it manually at a custom path:
 # app.mount("/my-mcp", get_mcp_app(engine))
 ```

--- a/ovos_translate_server/__init__.py
+++ b/ovos_translate_server/__init__.py
@@ -111,12 +111,16 @@ class TranslateEngineWrapper:
         return list(self.tx.available_languages or [])
 
 
-def create_app(engine: TranslateEngineWrapper) -> FastAPI:
+def create_app(engine: TranslateEngineWrapper, enable_mcp: bool = False) -> FastAPI:
     """Build and return the FastAPI application.
 
     Args:
         engine: Initialised :class:`TranslateEngineWrapper` to use for all
             requests.
+        enable_mcp: Mount the MCP server at ``/mcp``. Defaults to ``False``:
+            installing the ``mcp`` extra no longer auto-mounts the endpoint,
+            matching ``ovos-tts-server``. Pass ``True`` (e.g. the CLI's
+            ``--mcp`` flag) to opt in.
 
     Returns:
         Configured :class:`fastapi.FastAPI` instance with CORS enabled and all
@@ -237,17 +241,19 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
         return JSONResponse(build_utcp_manual(base_url))
 
     # ------------------------------------------------------------------
-    # MCP server — optional, requires `pip install ovos-translate-server[mcp]`
+    # MCP server — opt-in via enable_mcp / the CLI's --mcp flag, requires
+    # `pip install ovos-translate-server[mcp]`
     # ------------------------------------------------------------------
-    try:
-        from ovos_translate_server.mcp_server import mount_mcp
-        mount_mcp(app, engine)
-        LOG.info("MCP server mounted at /mcp")
-    except ImportError:
-        LOG.debug(
-            "MCP support not available. "
-            "Install with: pip install 'ovos-translate-server[mcp]'"
-        )
+    if enable_mcp:
+        try:
+            from ovos_translate_server.mcp_server import mount_mcp
+            mount_mcp(app, engine)
+            LOG.info("MCP server mounted at /mcp")
+        except ImportError:
+            LOG.warning(
+                "MCP support requested (--mcp) but not available. "
+                "Install with: pip install 'ovos-translate-server[mcp]'"
+            )
 
     return app
 
@@ -255,6 +261,7 @@ def create_app(engine: TranslateEngineWrapper) -> FastAPI:
 def start_translate_server(
     tx_engine: str,
     detect_engine: Optional[str] = None,
+    enable_mcp: bool = False,
 ) -> Tuple["FastAPI", "TranslateEngineWrapper"]:
     """Create and return the FastAPI app and engine wrapper.
 
@@ -264,11 +271,12 @@ def start_translate_server(
     Args:
         tx_engine: OPM entry-point name of the translation plugin.
         detect_engine: OPM entry-point name of the detection plugin (optional).
+        enable_mcp: Mount the MCP server at ``/mcp``. Defaults to ``False``.
 
     Returns:
         A ``(app, engine)`` tuple where *app* is a :class:`fastapi.FastAPI`
         instance and *engine* is the :class:`TranslateEngineWrapper`.
     """
     engine = TranslateEngineWrapper(tx_engine, detect_engine)
-    app = create_app(engine)
+    app = create_app(engine, enable_mcp=enable_mcp)
     return app, engine

--- a/ovos_translate_server/__main__.py
+++ b/ovos_translate_server/__main__.py
@@ -34,9 +34,15 @@ def main() -> None:
     )
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind (default: 0.0.0.0)")
     parser.add_argument("--port", type=int, default=9686, help="TCP port (default: 9686)")
+    parser.add_argument(
+        "--mcp",
+        help="mount MCP server at /mcp (requires ovos-translate-server[mcp])",
+        action="store_true",
+    )
     args = parser.parse_args()
 
-    app, _ = start_translate_server(args.tx_engine, args.detect_engine)
+    app, _ = start_translate_server(args.tx_engine, args.detect_engine,
+                                     enable_mcp=bool(args.mcp))
     uvicorn.run(app, host=args.host, port=args.port)
 
 

--- a/test/test_fastapi_base.py
+++ b/test/test_fastapi_base.py
@@ -283,3 +283,47 @@ class TestStartTranslateServer:
             _, engine = start_translate_server("my-plugin")
         assert isinstance(engine, TranslateEngineWrapper)
         assert engine.plugin_name == "my-plugin"
+
+
+def _has_mcp_mount(app) -> bool:
+    """True if *app* has a route/mount whose path is or starts with /mcp.
+
+    Some entries under ``app.routes`` (e.g. included routers) don't expose a
+    ``.path`` attribute, so skip those rather than assuming every route does.
+    """
+    for route in app.routes:
+        path = getattr(route, "path", None)
+        if path is not None and (path == "/mcp" or path.startswith("/mcp")):
+            return True
+    return False
+
+
+class TestMcpOptIn:
+    """MCP mounting must be explicit opt-in via enable_mcp / the CLI --mcp
+    flag, matching ovos-tts-server. Installing the `mcp` extra alone must not
+    auto-mount /mcp."""
+
+    def test_default_does_not_mount_mcp(self):
+        engine, app = _make_engine()
+        assert not _has_mcp_mount(app)
+
+    def test_enable_mcp_false_does_not_mount(self):
+        from ovos_translate_server import create_app
+        engine, _ = _make_engine()
+        app = create_app(engine, enable_mcp=False)
+        assert not _has_mcp_mount(app)
+
+    def test_enable_mcp_true_mounts_mcp_route(self):
+        from ovos_translate_server import create_app
+        pytest.importorskip("fastmcp", reason="fastmcp package not installed")
+        engine, _ = _make_engine()
+        app = create_app(engine, enable_mcp=True)
+        assert _has_mcp_mount(app)
+
+    def test_start_translate_server_default_enable_mcp_is_false(self):
+        from ovos_translate_server import start_translate_server
+        tx = MagicMock()
+        tx.available_languages = ["en"]
+        with patch("ovos_translate_server.load_tx_plugin", return_value=MagicMock(return_value=tx)):
+            app, _ = start_translate_server("my-plugin")
+        assert not _has_mcp_mount(app)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

MCP enablement is inconsistent across the four OVOS servers: ovos-tts-server only mounts /mcp with an explicit --mcp flag, while this repo, persona-server, and stt-server all mounted it automatically whenever the mcp extra happened to be importable. Installing an extra shouldn't silently expose a tool endpoint, and operators shouldn't have to remember which server behaves which way. --mcp is the agreed standard across the servers, so this brings translate-server in line.

create_app and start_translate_server both gain an enable_mcp flag that defaults to False, and MCP only mounts when it's True. __main__.py gets a --mcp flag matching ovos-tts-server's naming and help text. Passing --mcp without the mcp extra installed used to silently do nothing; now it logs a clear warning naming the install command instead, since a silent no-op there is the worse failure mode. The README's extras table and MCP section are updated to say the flag is required, not just the extra.

This is a breaking change for any deployment that installed the mcp extra and relied on it auto-mounting — /mcp stops being exposed until --mcp is passed explicitly, with no compatibility environment-variable fallback, matching the precedent already set in tts-server. One follow-up flagged for the maintainer: ovos-plugin-linguonnx's Docker image runs this server via its own ENTRYPOINT and will need --mcp added there once this merges, or its embedded MCP endpoint will quietly stop being mounted.

4 new tests in test/test_fastapi_base.py check both directions — no flag or enable_mcp=False mounts nothing, enable_mcp=True mounts the /mcp route (skipped if fastmcp isn't installed). All 4 were confirmed to fail against the pre-fix code and pass after. The full suite, matching CI's extras (mcp,test), is 183 passed.
